### PR TITLE
Add support for CSS color function notation to Led.RGB.color()

### DIFF
--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -312,6 +312,16 @@ RGB.ToRGB = function(red, green, blue) {
           green: parseInt(input.slice(2, 4), 16),
           blue: parseInt(input.slice(4, 6), 16)
         };
+      } else if (/^rgb/.test(input)) {
+        var args = input.match(/^rgba?\(([^)]+)\)$/)[1].split(',');
+        update = {
+          red: parseInt(args[0], 10),
+          green: parseInt(args[1], 10),
+          blue: parseInt(args[2], 10)
+        };
+        if (args.length > 3) {
+          update = RGB.ToScaledRGB(100 * parseFloat(args[3]), update);
+        }
       } else {
         // color name
         return RGB.ToRGB(converter.keyword.rgb(input.toLowerCase()));

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -313,7 +313,7 @@ RGB.ToRGB = function(red, green, blue) {
           blue: parseInt(input.slice(4, 6), 16)
         };
       } else if (/^rgb/.test(input)) {
-        var args = input.match(/^rgba?\(([^)]+)\)$/)[1].split(',');
+        var args = input.match(/^rgba?\(([^)]+)\)$/)[1].split(/[\s,]+/);
         update = {
           red: parseInt(args[0], 10),
           green: parseInt(args[1], 10),

--- a/test/rgb.js
+++ b/test/rgb.js
@@ -230,7 +230,7 @@ exports["RGB"] = {
     this.write.reset();
 
     // CSS functional notation
-    this.rgb.color('rgb(255, 100, 50)');
+    this.rgb.color("rgb(255, 100, 50)");
     test.ok(this.write.calledOnce);
     test.ok(this.write.calledWith({
       red: 255,
@@ -242,7 +242,7 @@ exports["RGB"] = {
     // CSS functional notation with alpha
     // Subtle bug: Alpha is translated to intensity using linear scaling
     // when it should probably use logarithmic scaling.
-    this.rgb.color('rgba(255, 100, 50, 0.5)');
+    this.rgb.color("rgba(255, 100, 50, 0.5)");
     test.ok(this.write.calledOnce);
     test.ok(this.write.calledWith({
       red: 128,
@@ -252,7 +252,7 @@ exports["RGB"] = {
     this.write.reset();
 
     // CSS4 functional notation (rgb and rgba become aliases)
-    this.rgb.color('rgba(255, 100, 50)');
+    this.rgb.color("rgba(255, 100, 50)");
     test.ok(this.write.calledOnce);
     test.ok(this.write.calledWith({
       red: 255,
@@ -263,7 +263,7 @@ exports["RGB"] = {
 
     // CSS4 functional notation with alpha (rgb and rgba become aliases)
     // Also testing with no spaces to make sure that's supported.
-    this.rgb.color('rgb(255,100,50,0.5)');
+    this.rgb.color("rgb(255,100,50,0.5)");
     test.ok(this.write.calledOnce);
     test.ok(this.write.calledWith({
       red: 128,
@@ -273,7 +273,7 @@ exports["RGB"] = {
     this.write.reset();
 
     // CSS4 functional notation without commas
-    this.rgb.color('rgb(255 100 50)');
+    this.rgb.color("rgb(255 100 50)");
     test.ok(this.write.calledOnce);
     test.ok(this.write.calledWith({
       red: 255,

--- a/test/rgb.js
+++ b/test/rgb.js
@@ -130,7 +130,7 @@ exports["RGB"] = {
   color: function(test) {
     var rgb = this.rgb;
 
-    test.expect(36);
+    test.expect(44);
 
     // returns this
     test.equal(this.rgb.color("#000000"), this.rgb);
@@ -226,6 +226,48 @@ exports["RGB"] = {
       red: 255,
       green: 100,
       blue: 50
+    }));
+    this.write.reset();
+
+    // CSS functional notation
+    this.rgb.color('rgb(255, 100, 50)');
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({
+      red: 255,
+      green: 100,
+      blue: 50
+    }));
+    this.write.reset();
+
+    // CSS functional notation with alpha
+    // Subtle bug: Alpha is translated to intensity using linear scaling
+    // when it should probably use logarithmic scaling.
+    this.rgb.color('rgba(255, 100, 50, 0.5)');
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({
+      red: 128,
+      green: 50,
+      blue: 25
+    }));
+    this.write.reset();
+
+    // CSS4 functional notation (rgb and rgba become aliases)
+    this.rgb.color('rgba(255, 100, 50)');
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({
+      red: 255,
+      green: 100,
+      blue: 50
+    }));
+    this.write.reset();
+
+    // CSS4 functional notation with alpha (rgb and rgba become aliases)
+    this.rgb.color('rgb(255, 100, 50, 0.5)');
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({
+      red: 128,
+      green: 50,
+      blue: 25
     }));
     this.write.reset();
 

--- a/test/rgb.js
+++ b/test/rgb.js
@@ -130,7 +130,7 @@ exports["RGB"] = {
   color: function(test) {
     var rgb = this.rgb;
 
-    test.expect(44);
+    test.expect(46);
 
     // returns this
     test.equal(this.rgb.color("#000000"), this.rgb);
@@ -262,12 +262,23 @@ exports["RGB"] = {
     this.write.reset();
 
     // CSS4 functional notation with alpha (rgb and rgba become aliases)
-    this.rgb.color('rgb(255, 100, 50, 0.5)');
+    // Also testing with no spaces to make sure that's supported.
+    this.rgb.color('rgb(255,100,50,0.5)');
     test.ok(this.write.calledOnce);
     test.ok(this.write.calledWith({
       red: 128,
       green: 50,
       blue: 25
+    }));
+    this.write.reset();
+
+    // CSS4 functional notation without commas
+    this.rgb.color('rgb(255 100 50)');
+    test.ok(this.write.calledOnce);
+    test.ok(this.write.calledWith({
+      red: 255,
+      green: 100,
+      blue: 50
     }));
     this.write.reset();
 


### PR DESCRIPTION
_This applies changes I've submitted upstream in https://github.com/rwaldron/johnny-five/pull/1320 to our Code.org-specific version early._

Adds support for CSS color function notation (e.g. `"rgb(255, 255, 0)"`) to the `color()` method on the Led.RGB prototype.  Based on the [CSS Color Module Level 4 Draft](https://drafts.csswg.org/css-color/#rgb-functions) and [the Color article at MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb())

You can now call `led.color()` with the following strings:

  - `"rgb(r, g, b)"` where `r`, `g`, and `b` are numbers in the range 0-255.
  - `"rgb(r, g, b, a)"` where `a` is in the range 0-1 and modifies the color as an intensity function using `RGB.ToScaledRGB()`
  - `"rgba(r, g, b)"` or `"rgba(r, g, b, a)"` because `rgba` is an alias of `rgb` as of the Level 4 Draft.
  - `"rgb(r,g,b)"` or `"rgb(r g b)"` because arguments can be separated by whitespace, commas, or both as of the Level 4 Draft.