### PR TITLE
Fix Piezo.prototype.note()

### DIFF
--- a/lib/piezo.js
+++ b/lib/piezo.js
@@ -401,16 +401,37 @@ Piezo.ToSong = function(stringSong, beats) {
   return song;
 };
 
+/**
+ * Play a note for a duration.
+ * @param {string} note - see Piezo.Notes.  Case-insensitive.
+ *   If a note name without an octave number is given (e.g. "C#" instead of
+ *   "C#4") then the configured default octave will be used.
+ *   @see Piezo.prototype.defaultOctave
+ * @param {number} duration - in milliseconds.
+ */
 Piezo.prototype.note = function(note, duration) {
-  var tone = Piezo.Parsers.hzFromInput(note);
-
-  return this.tone(tone, duration);
+  return this.frequency(Piezo.Parsers.hzFromInput(note), duration);
 };
 
+/**
+ * Play a tone for a duration.
+ * This is a lower-level method than frequency (which does
+ * the translation from frequency to tone for you). Most of
+ * the time you likely want to use frequency.
+ * @param {number} tone - Given as a computed duty-cycle,
+ *   in microseconds. Larger values produce lower tones.
+ *   See https://en.wikipedia.org/wiki/Duty_cycle
+ * @param {number} duration - in milliseconds.
+ */
 Piezo.prototype.tone = function(tone, duration) {
   return this.frequency(Piezo.ToFrequency(tone), duration);
 };
 
+/**
+ * Play a frequency for a duration.
+ * @param {number} frequency - in Hz
+ * @param {number} duration - in milliseconds
+ */
 Piezo.prototype.frequency = function(frequency, duration) {
   return this.tone(Piezo.ToTone(frequency), duration);
 };


### PR DESCRIPTION
This commit applies upstream fix https://github.com/rwaldron/johnny-five/pull/1324 for issue https://github.com/rwaldron/johnny-five/issues/1323 to code-dot-org/johnny-five early, even though we're behind.  This should merge trivially when we catch up.

The `note()` method was passing a frequency (Hz) to the `tone()` method, which is expecting to receive a duty cycle (μs), leading to the wrong note being played.  The solution is for `note()` to call `frequency()` instead, which will do the appropriate conversion.

Since it took me a while to understand the relationships between `tone`, `frequency` and `note` I've added some documentation to those methods to clear things up for the next person.  I've also made some unit tests more aggressive about checking that values are converted appropriately as they're passed around, and commented note-frequency-duty equivalencies to help the test read nicer.

Includes squashed fixups:

- Fix lint error.
- Address review feedback:
  - Test that `note()` is case-insensitive
  - Better description of default octave
  - One-line Piezo.prototype.note
  - s/frequncy/frequency
  - Note tests demonstrate the difference between note letter and octave number better