### PR TITLE
Make unit tests less flaky on Travis CI

### DIFF
--- a/test/animation.js
+++ b/test/animation.js
@@ -244,7 +244,10 @@ exports["Animation -- Servo"] = {
   },
 
   keyframeEasing: function(test) {
-
+    // Don't allow time to advance in this test.  Otherwise it's possible for
+    // the animation to progress between setup and the assertion, causing flaky
+    // failures.
+    this.sandbox.useFakeTimers();
     this.animation = new Animation(this.a);
     test.expect(1);
 
@@ -261,7 +264,8 @@ exports["Animation -- Servo"] = {
     var indices = this.animation.findIndices(progress);
     var val = this.animation.tweenedValue(indices, progress);
 
-    test.ok(Math.abs(val - 74.843 < 0.01));
+    test.ok(Math.abs(val - 74.843) < 0.01,
+      "Expected " + val + " to be within 0.01 of 74.843");
     test.done();
   },
 

--- a/test/repl.js
+++ b/test/repl.js
@@ -38,9 +38,16 @@ exports["Repl"] = {
       debug: false
     });
 
+    // Extra-careful guard against calling test.done() twice here.
+    // This was causing "Cannot read property 'setUp' of undefined" errors
+    // See https://github.com/caolan/nodeunit/issues/234
+    var calledTestDone = false;
     var reallyExit = this.sandbox.stub(process, "reallyExit", function() {
       reallyExit.restore();
-      test.done();
+      if (!calledTestDone) {
+        calledTestDone = true;
+        test.done();
+      }
     });
 
     board.on("ready", function() {


### PR DESCRIPTION
Pulling upstream fix from https://github.com/rwaldron/johnny-five/pull/1329 into our fork early.  See that PR for comments explaining this change and measurements of reduced flakiness over several runs.