### PR TITLE
Customize package.json and README for Code.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@
 
 _Artwork by [Mike Sgier](http://msgierillustration.com)_
 
-[![Travis Build Status](https://travis-ci.org/rwaldron/johnny-five.svg?branch=master)](https://travis-ci.org/rwaldron/johnny-five)
-[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/hmke71k7uemtnami/branch/master?svg=true)](https://ci.appveyor.com/project/rwaldron/johnny-five)
-[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/rwaldron/johnny-five?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+<!-- Customized for Code.org -->
+[![Travis Build Status](https://travis-ci.org/code-dot-org/johnny-five.svg?branch=master)](https://travis-ci.org/code-dot-org/johnny-five)
+<!-- No appveyor or gitter -->
 
-
+_This is the [Code.org](https://code.org) fork of johnny-five.  Please [check out the main project here!](https://github.com/rwaldron/johnny-five)_
+<!-- End of Code.org customizations -->
 
 **Johnny-Five is an Open Source, Firmata Protocol based, IoT and Robotics programming framework, developed at [Bocoup](http://bocoup.com). Johnny-Five programs can be written for Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/johnny-five",
-  "description": "The JavaScript Robotics and Hardware Programming Framework. Use with: Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!",
+  "description": "Code.org fork of rwaldron/johnny-five: The JavaScript Robotics and Hardware Programming Framework. Use with: Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!",
   "version": "0.10.10-cdo.0",
   "homepage": "https://johnny-five.io",
   "author": {
@@ -249,10 +249,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/rwaldron/johnny-five.git"
+    "url": "git://github.com/code-dot-org/johnny-five.git"
   },
   "bugs": {
-    "url": "https://github.com/rwaldron/johnny-five/issues"
+    "url": "https://github.com/code-dot-org/johnny-five/issues"
   },
   "license": "MIT",
   "main": "lib/johnny-five",

--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -7,11 +7,12 @@
 
 _Artwork by [Mike Sgier](http://msgierillustration.com)_
 
-[![Travis Build Status](https://travis-ci.org/rwaldron/johnny-five.svg?branch=master)](https://travis-ci.org/rwaldron/johnny-five)
-[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/hmke71k7uemtnami/branch/master?svg=true)](https://ci.appveyor.com/project/rwaldron/johnny-five)
-[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/rwaldron/johnny-five?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+<!-- Customized for Code.org -->
+[![Travis Build Status](https://travis-ci.org/code-dot-org/johnny-five.svg?branch=master)](https://travis-ci.org/code-dot-org/johnny-five)
+<!-- No appveyor or gitter -->
 
-
+_This is the [Code.org](https://code.org) fork of johnny-five.  Please [check out the main project here!](https://github.com/rwaldron/johnny-five)_
+<!-- End of Code.org customizations -->
 
 **Johnny-Five is an Open Source, Firmata Protocol based, IoT and Robotics programming framework, developed at [Bocoup](http://bocoup.com). Johnny-Five programs can be written for Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!**
 


### PR DESCRIPTION
Some small changes to promote transparency on our fork and help point people back to the main repo if they end up here by accident.
- Adds a note near the top of the README that this is our fork, and linking to the original repo.  Hides badges not relevant to our repo, updates Travis badge to point at our builds.
- Adjusts package name and repo links in package.json for better metadata on npmjs.org.