### PR TITLE
Animation uses fallback timer immediately

### DIFF
--- a/lib/animation.js
+++ b/lib/animation.js
@@ -17,7 +17,10 @@ var temporal;
  * time (in ms) is reached we will fall back to setInterval which is less
  * accurate (by nanoseconds) but perfectly serviceable.
  **/
-var temporalTTL = 5000;
+// Code.org: Temporal is too CPU-intensive for our purposes.  We set this
+// value to zero so that Animation switches to a setInterval fallback mode
+// immediately, which works better for our purposes.
+var temporalTTL = 0;
 
 /**
  * Placeholders for Symbol

--- a/test/servo.js
+++ b/test/servo.js
@@ -602,7 +602,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1000);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1000);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", function() {
@@ -672,7 +673,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1500);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1500);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", function() {
@@ -742,7 +744,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1500);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1500);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", function() {
@@ -812,7 +815,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1000);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1000);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", function() {
@@ -884,7 +888,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1000);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1000);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", function() {
@@ -913,7 +918,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1500);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1500);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     test.done();


### PR DESCRIPTION
See https://github.com/code-dot-org/code-dot-org/pull/18655 for a more general discussion of the problem I'm trying to solve and the original approach I tried.  I think this is a better solution though.

The 'temporal' library being used for animation in johnny-five, while great for robotics, is too CPU-intensive for use in Maker Lab.  There's already a mechanism for falling back on a setInterval-based solution for animations that run longer than 5 seconds.  By tuning that fallback timeout down to zero we can use the setInterval fallback immediately and avoid the performance impact of temporal.

Animation is the only place in johnny-five that temporal is used, so we don't have to do this anywhere else.

If upstream ever makes this fallback officially configurable, we won't need this customization anymore.