### PR TITLE
Add RGB.pulse method

### DIFF
--- a/docs/accelerometer-LIS3DH.md
+++ b/docs/accelerometer-LIS3DH.md
@@ -77,7 +77,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/accelerometer-MMA8452.md
+++ b/docs/accelerometer-MMA8452.md
@@ -74,7 +74,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/accelerometer-adxl335.md
+++ b/docs/accelerometer-adxl335.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/accelerometer-adxl345.md
+++ b/docs/accelerometer-adxl345.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/accelerometer-mma7361.md
+++ b/docs/accelerometer-mma7361.md
@@ -82,7 +82,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/accelerometer-mpu6050.md
+++ b/docs/accelerometer-mpu6050.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/accelerometer-pan-tilt.md
+++ b/docs/accelerometer-pan-tilt.md
@@ -76,7 +76,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/accelerometer.md
+++ b/docs/accelerometer.md
@@ -131,7 +131,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/altimeter-BMP085.md
+++ b/docs/altimeter-BMP085.md
@@ -114,7 +114,7 @@ Fritzing diagram: [docs/breadboard/multi-bmp085.fzz](breadboard/multi-bmp085.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/altimeter-BMP180.md
+++ b/docs/altimeter-BMP180.md
@@ -116,7 +116,7 @@ Fritzing diagram: [docs/breadboard/multi-bmp180.fzz](breadboard/multi-bmp180.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/altimeter-MS5611.md
+++ b/docs/altimeter-MS5611.md
@@ -96,7 +96,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/altimeter-mpl3115a2.md
+++ b/docs/altimeter-mpl3115a2.md
@@ -77,7 +77,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/barometer-BMP085.md
+++ b/docs/barometer-BMP085.md
@@ -78,7 +78,7 @@ Fritzing diagram: [docs/breadboard/multi-bmp085.fzz](breadboard/multi-bmp085.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/barometer-BMP180.md
+++ b/docs/barometer-BMP180.md
@@ -80,7 +80,7 @@ Fritzing diagram: [docs/breadboard/multi-bmp180.fzz](breadboard/multi-bmp180.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/barometer-MS5611.md
+++ b/docs/barometer-MS5611.md
@@ -60,7 +60,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/barometer-mpl115a2.md
+++ b/docs/barometer-mpl115a2.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/barometer-mpl3115a2.md
+++ b/docs/barometer-mpl3115a2.md
@@ -72,7 +72,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/board-cleanup.md
+++ b/docs/board-cleanup.md
@@ -58,7 +58,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/board-multi.md
+++ b/docs/board-multi.md
@@ -103,7 +103,7 @@ boards.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/board-sampling-interval.md
+++ b/docs/board-sampling-interval.md
@@ -63,7 +63,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/board-with-port.md
+++ b/docs/board-with-port.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/board.md
+++ b/docs/board.md
@@ -59,7 +59,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/boe-test-servos.md
+++ b/docs/boe-test-servos.md
@@ -286,7 +286,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/brat.md
+++ b/docs/brat.md
@@ -647,7 +647,7 @@ Example control of biped robot
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/bug.md
+++ b/docs/bug.md
@@ -233,7 +233,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/button-EVS_EV3.md
+++ b/docs/button-EVS_EV3.md
@@ -77,7 +77,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/button-EVS_NXT.md
+++ b/docs/button-EVS_NXT.md
@@ -77,7 +77,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/button-bumper.md
+++ b/docs/button-bumper.md
@@ -64,7 +64,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/button-collection-AT42QT1070.md
+++ b/docs/button-collection-AT42QT1070.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/button-options.md
+++ b/docs/button-options.md
@@ -87,7 +87,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/button-pullup.md
+++ b/docs/button-pullup.md
@@ -79,7 +79,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/button.md
+++ b/docs/button.md
@@ -84,7 +84,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/classic-controller.md
+++ b/docs/classic-controller.md
@@ -133,7 +133,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/claw.md
+++ b/docs/claw.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/color-EVS_EV3.md
+++ b/docs/color-EVS_EV3.md
@@ -49,7 +49,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/color-EVS_NXT.md
+++ b/docs/color-EVS_NXT.md
@@ -49,7 +49,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/color-ISL29125.md
+++ b/docs/color-ISL29125.md
@@ -51,7 +51,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/color-raw-EVS_EV3.md
+++ b/docs/color-raw-EVS_EV3.md
@@ -50,7 +50,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/compass-MAG3110-tessel.md
+++ b/docs/compass-MAG3110-tessel.md
@@ -77,7 +77,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/compass-MAG3110.md
+++ b/docs/compass-MAG3110.md
@@ -74,7 +74,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/compass-hmc5883l.md
+++ b/docs/compass-hmc5883l.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/compass-hmc6352.md
+++ b/docs/compass-hmc6352.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/custom-properties.md
+++ b/docs/custom-properties.md
@@ -52,7 +52,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/edison-io-arduino.md
+++ b/docs/edison-io-arduino.md
@@ -79,7 +79,7 @@ npm install johnny-five edison-io
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/edison-io-miniboard.md
+++ b/docs/edison-io-miniboard.md
@@ -79,7 +79,7 @@ npm install johnny-five edison-io
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/esc-PCA9685.md
+++ b/docs/esc-PCA9685.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/esc-array.md
+++ b/docs/esc-array.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/esc-bidirectional-forward-reverse.md
+++ b/docs/esc-bidirectional-forward-reverse.md
@@ -81,7 +81,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/esc-bidirectional.md
+++ b/docs/esc-bidirectional.md
@@ -74,7 +74,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/esc-dualshock.md
+++ b/docs/esc-dualshock.md
@@ -99,7 +99,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/esc-keypress.md
+++ b/docs/esc-keypress.md
@@ -84,7 +84,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-74HC595.md
+++ b/docs/expander-74HC595.md
@@ -69,7 +69,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-CD74HC4067_NANO_BACKPACK.md
+++ b/docs/expander-CD74HC4067_NANO_BACKPACK.md
@@ -98,7 +98,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-LIS3DH.md
+++ b/docs/expander-LIS3DH.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-MCP23008.md
+++ b/docs/expander-MCP23008.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-MCP23017.md
+++ b/docs/expander-MCP23017.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-MUXSHIELD2-analog-read.md
+++ b/docs/expander-MUXSHIELD2-analog-read.md
@@ -83,7 +83,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-MUXSHIELD2-mixed.md
+++ b/docs/expander-MUXSHIELD2-mixed.md
@@ -118,7 +118,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-PCA9685.md
+++ b/docs/expander-PCA9685.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-PCF8574.md
+++ b/docs/expander-PCF8574.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-PCF8575.md
+++ b/docs/expander-PCF8575.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/expander-PCF8591.md
+++ b/docs/expander-PCF8591.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/galileo-io.md
+++ b/docs/galileo-io.md
@@ -79,7 +79,7 @@ npm install johnny-five galileo-io
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/gps-GP-20U7.md
+++ b/docs/gps-GP-20U7.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/gps-adafruit.md
+++ b/docs/gps-adafruit.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/gps.md
+++ b/docs/gps.md
@@ -80,7 +80,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-accelerometer-adxl345-edison.md
+++ b/docs/grove-accelerometer-adxl345-edison.md
@@ -70,7 +70,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-accelerometer-mma7660-edison.md
+++ b/docs/grove-accelerometer-mma7660-edison.md
@@ -70,7 +70,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-barometer-edison.md
+++ b/docs/grove-barometer-edison.md
@@ -64,7 +64,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-button-edison.md
+++ b/docs/grove-button-edison.md
@@ -72,7 +72,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-button.md
+++ b/docs/grove-button.md
@@ -66,7 +66,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-compass-edison.md
+++ b/docs/grove-compass-edison.md
@@ -71,7 +71,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-flame-sensor-edison.md
+++ b/docs/grove-flame-sensor-edison.md
@@ -67,7 +67,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-gas-mq2-edison.md
+++ b/docs/grove-gas-mq2-edison.md
@@ -68,7 +68,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-gas-tp401-edison.md
+++ b/docs/grove-gas-tp401-edison.md
@@ -107,7 +107,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-humidity-temperature-edison.md
+++ b/docs/grove-humidity-temperature-edison.md
@@ -79,7 +79,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-i2c-motor-driver-edison.md
+++ b/docs/grove-i2c-motor-driver-edison.md
@@ -85,7 +85,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-i2c-motor-driver.md
+++ b/docs/grove-i2c-motor-driver.md
@@ -79,7 +79,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-joystick-edison.md
+++ b/docs/grove-joystick-edison.md
@@ -66,7 +66,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-joystick.md
+++ b/docs/grove-joystick.md
@@ -59,7 +59,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-lcd-rgb-bgcolor-previewer-edison.md
+++ b/docs/grove-lcd-rgb-bgcolor-previewer-edison.md
@@ -73,7 +73,7 @@ board.on("ready", () => {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-lcd-rgb-edison.md
+++ b/docs/grove-lcd-rgb-edison.md
@@ -83,7 +83,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-lcd-rgb-temperature-display-edison.md
+++ b/docs/grove-lcd-rgb-temperature-display-edison.md
@@ -101,7 +101,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-lcd-rgb-temperature-display.md
+++ b/docs/grove-lcd-rgb-temperature-display.md
@@ -108,7 +108,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-lcd-rgb.md
+++ b/docs/grove-lcd-rgb.md
@@ -88,7 +88,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-led-edison.md
+++ b/docs/grove-led-edison.md
@@ -74,7 +74,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-led.md
+++ b/docs/grove-led.md
@@ -68,7 +68,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-light-sensor-edison.md
+++ b/docs/grove-light-sensor-edison.md
@@ -62,7 +62,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-moisture-edison.md
+++ b/docs/grove-moisture-edison.md
@@ -73,7 +73,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-q-touch.md
+++ b/docs/grove-q-touch.md
@@ -87,7 +87,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-relay-edison.md
+++ b/docs/grove-relay-edison.md
@@ -63,7 +63,7 @@ Learn More At:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-rotary-potentiometer-edison.md
+++ b/docs/grove-rotary-potentiometer-edison.md
@@ -90,7 +90,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-rotary-potentiometer.md
+++ b/docs/grove-rotary-potentiometer.md
@@ -84,7 +84,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-servo-edison.md
+++ b/docs/grove-servo-edison.md
@@ -70,7 +70,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-servo.md
+++ b/docs/grove-servo.md
@@ -64,7 +64,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-touch-edison.md
+++ b/docs/grove-touch-edison.md
@@ -74,7 +74,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/grove-touch.md
+++ b/docs/grove-touch.md
@@ -68,7 +68,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/gyro-lpr5150l.md
+++ b/docs/gyro-lpr5150l.md
@@ -66,7 +66,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/gyro-mpu6050.md
+++ b/docs/gyro-mpu6050.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/gyro.md
+++ b/docs/gyro.md
@@ -113,7 +113,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/hygrometer-DHT11_I2C_NANO_BACKPACK.md
+++ b/docs/hygrometer-DHT11_I2C_NANO_BACKPACK.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/hygrometer-DHT21_I2C_NANO_BACKPACK.md
+++ b/docs/hygrometer-DHT21_I2C_NANO_BACKPACK.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/hygrometer-DHT22_I2C_NANO_BACKPACK.md
+++ b/docs/hygrometer-DHT22_I2C_NANO_BACKPACK.md
@@ -66,7 +66,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/hygrometer-HIH6130.md
+++ b/docs/hygrometer-HIH6130.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/hygrometer-SI7021.md
+++ b/docs/hygrometer-SI7021.md
@@ -63,7 +63,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/hygrometer-TH02.md
+++ b/docs/hygrometer-TH02.md
@@ -55,7 +55,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/hygrometer-htu21d.md
+++ b/docs/hygrometer-htu21d.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/hygrometer-sht31d.md
+++ b/docs/hygrometer-sht31d.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/imp-io.md
+++ b/docs/imp-io.md
@@ -95,7 +95,7 @@ source ~/.imprc
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/imu-bno055-orientation.md
+++ b/docs/imu-bno055-orientation.md
@@ -92,7 +92,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/imu-bno055.md
+++ b/docs/imu-bno055.md
@@ -110,7 +110,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/imu-mpu6050.md
+++ b/docs/imu-mpu6050.md
@@ -85,7 +85,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/ir-motion.md
+++ b/docs/ir-motion.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/ir-proximity.md
+++ b/docs/ir-proximity.md
@@ -88,7 +88,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/ir-reflect-array.md
+++ b/docs/ir-reflect-array.md
@@ -62,7 +62,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/ir-reflect.md
+++ b/docs/ir-reflect.md
@@ -60,7 +60,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/joystick-esplora.md
+++ b/docs/joystick-esplora.md
@@ -70,7 +70,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/joystick-pantilt.md
+++ b/docs/joystick-pantilt.md
@@ -80,7 +80,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/joystick-shield.md
+++ b/docs/joystick-shield.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/joystick.md
+++ b/docs/joystick.md
@@ -79,7 +79,7 @@ Fritzing diagram: [docs/breadboard/joystick-adafruit.fzz](breadboard/joystick-ad
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-3X4_I2C_NANO_BACKPACK.md
+++ b/docs/keypad-3X4_I2C_NANO_BACKPACK.md
@@ -108,7 +108,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-MPR121-sensitivity.md
+++ b/docs/keypad-MPR121-sensitivity.md
@@ -101,7 +101,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-MPR121.md
+++ b/docs/keypad-MPR121.md
@@ -60,7 +60,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-MPR121QR2_SHIELD.md
+++ b/docs/keypad-MPR121QR2_SHIELD.md
@@ -88,7 +88,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-MPR121_KEYPAD.md
+++ b/docs/keypad-MPR121_KEYPAD.md
@@ -86,7 +86,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-MPR121_SHIELD.md
+++ b/docs/keypad-MPR121_SHIELD.md
@@ -87,7 +87,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-QTOUCH.md
+++ b/docs/keypad-QTOUCH.md
@@ -83,7 +83,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-analog-ad.md
+++ b/docs/keypad-analog-ad.md
@@ -88,7 +88,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/keypad-analog-vkey.md
+++ b/docs/keypad-analog-vkey.md
@@ -90,7 +90,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/kinect-arm-controller.md
+++ b/docs/kinect-arm-controller.md
@@ -425,7 +425,7 @@ Illustrates arm joint connections.
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/laser-trip-wire.md
+++ b/docs/laser-trip-wire.md
@@ -66,7 +66,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-16x2-tessel.md
+++ b/docs/lcd-16x2-tessel.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-enumeratechars.md
+++ b/docs/lcd-enumeratechars.md
@@ -96,7 +96,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-i2c-PCF8574.md
+++ b/docs/lcd-i2c-PCF8574.md
@@ -94,7 +94,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-i2c-runner.md
+++ b/docs/lcd-i2c-runner.md
@@ -88,7 +88,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-i2c.md
+++ b/docs/lcd-i2c.md
@@ -69,7 +69,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-rgb-bgcolor-previewer-tessel.md
+++ b/docs/lcd-rgb-bgcolor-previewer-tessel.md
@@ -82,7 +82,7 @@ board.on("ready", () => {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-rgb-bgcolor-previewer.md
+++ b/docs/lcd-rgb-bgcolor-previewer.md
@@ -79,7 +79,7 @@ board.on("ready", () => {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-rgb-tessel-grove-JHD1313M1.md
+++ b/docs/lcd-rgb-tessel-grove-JHD1313M1.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-runner-20x4.md
+++ b/docs/lcd-runner-20x4.md
@@ -92,7 +92,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd-runner.md
+++ b/docs/lcd-runner.md
@@ -89,7 +89,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/lcd.md
+++ b/docs/lcd.md
@@ -96,7 +96,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-PCA9685.md
+++ b/docs/led-PCA9685.md
@@ -71,7 +71,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-array-controller.md
+++ b/docs/led-array-controller.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-array.md
+++ b/docs/led-array.md
@@ -62,7 +62,7 @@ as `pulse()` or `fade()`
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-blink.md
+++ b/docs/led-blink.md
@@ -81,7 +81,7 @@ Fritzing diagram: [docs/breadboard/led-resistor.fzz](breadboard/led-resistor.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-chars-demo.md
+++ b/docs/led-chars-demo.md
@@ -72,7 +72,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-demo-sequence.md
+++ b/docs/led-demo-sequence.md
@@ -135,7 +135,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-digits-clock-HT16K33.md
+++ b/docs/led-digits-clock-HT16K33.md
@@ -72,7 +72,7 @@ Learn More:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-digits-clock-dual.md
+++ b/docs/led-digits-clock-dual.md
@@ -85,7 +85,7 @@ Learn More:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-digits-clock.md
+++ b/docs/led-digits-clock.md
@@ -103,7 +103,7 @@ Fritzing diagram: [docs/breadboard/led-digits-clock-arduino.fzz](breadboard/led-
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-enumeratechars.md
+++ b/docs/led-enumeratechars.md
@@ -83,7 +83,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-fade-animation.md
+++ b/docs/led-fade-animation.md
@@ -72,7 +72,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-fade-callback.md
+++ b/docs/led-fade-callback.md
@@ -84,7 +84,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-fade.md
+++ b/docs/led-fade.md
@@ -64,7 +64,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-matrix-HT16K33-16x8.md
+++ b/docs/led-matrix-HT16K33-16x8.md
@@ -93,7 +93,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-matrix-HT16K33.md
+++ b/docs/led-matrix-HT16K33.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-matrix-tutorial.md
+++ b/docs/led-matrix-tutorial.md
@@ -154,7 +154,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-matrix.md
+++ b/docs/led-matrix.md
@@ -95,7 +95,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-pulse-animation.md
+++ b/docs/led-pulse-animation.md
@@ -81,7 +81,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-pulse.md
+++ b/docs/led-pulse.md
@@ -70,7 +70,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-rainbow.md
+++ b/docs/led-rainbow.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-rgb-BLINKM.md
+++ b/docs/led-rgb-BLINKM.md
@@ -66,7 +66,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-rgb-anode-PCA9685.md
+++ b/docs/led-rgb-anode-PCA9685.md
@@ -90,7 +90,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-rgb-anode.md
+++ b/docs/led-rgb-anode.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-rgb-intensity.md
+++ b/docs/led-rgb-intensity.md
@@ -86,7 +86,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-rgb.md
+++ b/docs/led-rgb.md
@@ -86,7 +86,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-slider.md
+++ b/docs/led-slider.md
@@ -61,7 +61,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led-tessel-servo-module.md
+++ b/docs/led-tessel-servo-module.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/led.md
+++ b/docs/led.md
@@ -109,7 +109,7 @@ then
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/light-ambient-EVS_EV3.md
+++ b/docs/light-ambient-EVS_EV3.md
@@ -48,7 +48,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/light-ambient-EVS_NXT.md
+++ b/docs/light-ambient-EVS_NXT.md
@@ -48,7 +48,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/light-reflected-EVS_EV3.md
+++ b/docs/light-reflected-EVS_EV3.md
@@ -49,7 +49,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/light-reflected-EVS_NXT.md
+++ b/docs/light-reflected-EVS_NXT.md
@@ -49,7 +49,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/line-follower.md
+++ b/docs/line-follower.md
@@ -217,7 +217,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/magnetometer-log.md
+++ b/docs/magnetometer-log.md
@@ -150,7 +150,7 @@ colors = {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/magnetometer-north.md
+++ b/docs/magnetometer-north.md
@@ -111,7 +111,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/magnetometer.md
+++ b/docs/magnetometer.md
@@ -103,7 +103,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/micromagician-accelerometer.md
+++ b/docs/micromagician-accelerometer.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/micromagician-motor.md
+++ b/docs/micromagician-motor.md
@@ -80,7 +80,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/micromagician-servo.md
+++ b/docs/micromagician-servo.md
@@ -92,7 +92,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/microphone.md
+++ b/docs/microphone.md
@@ -57,7 +57,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motion-GP2Y0A60SZLF.md
+++ b/docs/motion-GP2Y0A60SZLF.md
@@ -76,7 +76,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motion-gp2y0d805z0f.md
+++ b/docs/motion-gp2y0d805z0f.md
@@ -82,7 +82,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motion-gp2y0d810z0f.md
+++ b/docs/motion-gp2y0d810z0f.md
@@ -76,7 +76,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motion-gp2y0d815z0f.md
+++ b/docs/motion-gp2y0d815z0f.md
@@ -76,7 +76,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motion.md
+++ b/docs/motion.md
@@ -80,7 +80,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motobot.md
+++ b/docs/motobot.md
@@ -116,7 +116,7 @@ Motobot chassis before addings
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-3-pin.md
+++ b/docs/motor-3-pin.md
@@ -127,7 +127,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-EVS_EV3.md
+++ b/docs/motor-EVS_EV3.md
@@ -59,7 +59,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-EVS_NXT.md
+++ b/docs/motor-EVS_NXT.md
@@ -59,7 +59,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-GROVE_I2C.md
+++ b/docs/motor-GROVE_I2C.md
@@ -80,7 +80,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-LUDUS.md
+++ b/docs/motor-LUDUS.md
@@ -74,7 +74,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-PCA9685.md
+++ b/docs/motor-PCA9685.md
@@ -84,7 +84,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-TB6612FNG.md
+++ b/docs/motor-TB6612FNG.md
@@ -80,7 +80,7 @@ Here's a breakdown of the pins used by these motor drivers, their corresponding 
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-brake.md
+++ b/docs/motor-brake.md
@@ -112,7 +112,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-current.md
+++ b/docs/motor-current.md
@@ -125,7 +125,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-directional.md
+++ b/docs/motor-directional.md
@@ -137,7 +137,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-enable.md
+++ b/docs/motor-enable.md
@@ -113,7 +113,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-hbridge-dual.md
+++ b/docs/motor-hbridge-dual.md
@@ -104,7 +104,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-hbridge.md
+++ b/docs/motor-hbridge.md
@@ -110,7 +110,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor-sparkfun-edison-hbridge.md
+++ b/docs/motor-sparkfun-edison-hbridge.md
@@ -93,7 +93,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/motor.md
+++ b/docs/motor.md
@@ -93,7 +93,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-BME280.md
+++ b/docs/multi-BME280.md
@@ -93,7 +93,7 @@ Fritzing diagram: [docs/breadboard/multi-BME280-arduino.fzz](breadboard/multi-BM
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-DHT11_I2C_NANO_BACKPACK.md
+++ b/docs/multi-DHT11_I2C_NANO_BACKPACK.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-DHT21_I2C_NANO_BACKPACK.md
+++ b/docs/multi-DHT21_I2C_NANO_BACKPACK.md
@@ -72,7 +72,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-DHT22_I2C_NANO_BACKPACK.md
+++ b/docs/multi-DHT22_I2C_NANO_BACKPACK.md
@@ -72,7 +72,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-HIH6130.md
+++ b/docs/multi-HIH6130.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-MS5611.md
+++ b/docs/multi-MS5611.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-SI7020.md
+++ b/docs/multi-SI7020.md
@@ -86,7 +86,7 @@ Fritzing diagram: [docs/breadboard/temperature-SI7020-uno.fzz](breadboard/temper
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-SI7021.md
+++ b/docs/multi-SI7021.md
@@ -82,7 +82,7 @@ Fritzing diagram: [docs/breadboard/multi-SI7021-uno.fzz](breadboard/multi-SI7021
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-TH02.md
+++ b/docs/multi-TH02.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-bmp085.md
+++ b/docs/multi-bmp085.md
@@ -89,7 +89,7 @@ Fritzing diagram: [docs/breadboard/multi-bmp085.fzz](breadboard/multi-bmp085.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-bmp180.md
+++ b/docs/multi-bmp180.md
@@ -91,7 +91,7 @@ Fritzing diagram: [docs/breadboard/multi-bmp180.fzz](breadboard/multi-bmp180.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-htu21d.md
+++ b/docs/multi-htu21d.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-mpl115a2.md
+++ b/docs/multi-mpl115a2.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-mpl3115a2.md
+++ b/docs/multi-mpl3115a2.md
@@ -87,7 +87,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/multi-sht31d.md
+++ b/docs/multi-sht31d.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/navigator.md
+++ b/docs/navigator.md
@@ -570,7 +570,7 @@ Navigator.prototype.pivot = function(which, time) {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/nodebot.md
+++ b/docs/nodebot.md
@@ -122,7 +122,7 @@ Nodebots come in many flavors, but this is a typical setup.
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/nunchuk.md
+++ b/docs/nunchuk.md
@@ -135,7 +135,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/pcduino-io.md
+++ b/docs/pcduino-io.md
@@ -69,7 +69,7 @@ npm install johnny-five pcduino-io
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/phoenix.md
+++ b/docs/phoenix.md
@@ -457,7 +457,7 @@ board = new five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/photoresistor.md
+++ b/docs/photoresistor.md
@@ -76,7 +76,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/piezo.md
+++ b/docs/piezo.md
@@ -97,7 +97,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/pin.md
+++ b/docs/pin.md
@@ -77,7 +77,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -78,7 +78,7 @@ module.exports = function(five) {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/potentiometer.md
+++ b/docs/potentiometer.md
@@ -76,7 +76,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-EVS_EV3_IR-alert.md
+++ b/docs/proximity-EVS_EV3_IR-alert.md
@@ -60,7 +60,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-EVS_EV3_IR.md
+++ b/docs/proximity-EVS_EV3_IR.md
@@ -55,7 +55,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-EVS_EV3_US-alert.md
+++ b/docs/proximity-EVS_EV3_US-alert.md
@@ -60,7 +60,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-EVS_EV3_US.md
+++ b/docs/proximity-EVS_EV3_US.md
@@ -55,7 +55,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-GP2Y0A710K0F.md
+++ b/docs/proximity-GP2Y0A710K0F.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-hcsr04-analog.md
+++ b/docs/proximity-hcsr04-analog.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-hcsr04-i2c.md
+++ b/docs/proximity-hcsr04-i2c.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-hcsr04.md
+++ b/docs/proximity-hcsr04.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-lidarlite.md
+++ b/docs/proximity-lidarlite.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-mb1000.md
+++ b/docs/proximity-mb1000.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-mb1003.md
+++ b/docs/proximity-mb1003.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-mb1010.md
+++ b/docs/proximity-mb1010.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-mb1230.md
+++ b/docs/proximity-mb1230.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity-srf10.md
+++ b/docs/proximity-srf10.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/proximity.md
+++ b/docs/proximity.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/radar.md
+++ b/docs/radar.md
@@ -164,7 +164,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/raspi-io.md
+++ b/docs/raspi-io.md
@@ -71,7 +71,7 @@ npm install johnny-five raspi-io
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/relay-collection.md
+++ b/docs/relay-collection.md
@@ -58,7 +58,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -81,7 +81,7 @@ Fritzing diagram: [docs/breadboard/relay-closed.fzz](breadboard/relay-closed.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -78,7 +78,7 @@ or
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/sensor-digital-microwave.md
+++ b/docs/sensor-digital-microwave.md
@@ -56,7 +56,7 @@ board.on("ready", () => {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/sensor-fsr.md
+++ b/docs/sensor-fsr.md
@@ -68,7 +68,7 @@ var five = require("johnny-five"),
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/sensor-photon-weather-shield-moisture.md
+++ b/docs/sensor-photon-weather-shield-moisture.md
@@ -77,7 +77,7 @@ For this program, you'll need:
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/sensor-slider.md
+++ b/docs/sensor-slider.md
@@ -58,7 +58,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -49,7 +49,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-PCA9685.md
+++ b/docs/servo-PCA9685.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-animation-leg.md
+++ b/docs/servo-animation-leg.md
@@ -140,7 +140,7 @@ var board = new five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-animation.md
+++ b/docs/servo-animation.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-array.md
+++ b/docs/servo-array.md
@@ -112,7 +112,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-continuous.md
+++ b/docs/servo-continuous.md
@@ -86,7 +86,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-drive.md
+++ b/docs/servo-drive.md
@@ -94,7 +94,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-prompt.md
+++ b/docs/servo-prompt.md
@@ -69,7 +69,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-slider.md
+++ b/docs/servo-slider.md
@@ -60,7 +60,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-sweep.md
+++ b/docs/servo-sweep.md
@@ -87,7 +87,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo-tessel-servo-module.md
+++ b/docs/servo-tessel-servo-module.md
@@ -55,7 +55,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/servo.md
+++ b/docs/servo.md
@@ -108,7 +108,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/shift-register-daisy-chain-anode.md
+++ b/docs/shift-register-daisy-chain-anode.md
@@ -108,7 +108,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/shift-register-daisy-chain.md
+++ b/docs/shift-register-daisy-chain.md
@@ -108,7 +108,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/shift-register-seven-segment-anode.md
+++ b/docs/shift-register-seven-segment-anode.md
@@ -81,7 +81,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/shift-register-seven-segment.md
+++ b/docs/shift-register-seven-segment.md
@@ -77,7 +77,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/shift-register.md
+++ b/docs/shift-register.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/spark-io.md
+++ b/docs/spark-io.md
@@ -99,7 +99,7 @@ Ensure your host computer (where you're running your Node application) and the S
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/stepper-driver.md
+++ b/docs/stepper-driver.md
@@ -91,7 +91,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/stepper-sweep.md
+++ b/docs/stepper-sweep.md
@@ -59,7 +59,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/switch-magnetic-door.md
+++ b/docs/switch-magnetic-door.md
@@ -66,7 +66,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/switch-tilt-SW_200D.md
+++ b/docs/switch-tilt-SW_200D.md
@@ -72,7 +72,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-BMP180.md
+++ b/docs/temperature-BMP180.md
@@ -83,7 +83,7 @@ Fritzing diagram: [docs/breadboard/multi-bmp180.fzz](breadboard/multi-bmp180.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-DHT11_I2C_NANO_BACKPACK.md
+++ b/docs/temperature-DHT11_I2C_NANO_BACKPACK.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-DHT21_I2C_NANO_BACKPACK.md
+++ b/docs/temperature-DHT21_I2C_NANO_BACKPACK.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-DHT22_I2C_NANO_BACKPACK.md
+++ b/docs/temperature-DHT22_I2C_NANO_BACKPACK.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-HIH6130.md
+++ b/docs/temperature-HIH6130.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-MCP9808.md
+++ b/docs/temperature-MCP9808.md
@@ -78,7 +78,7 @@ Fritzing diagram: [docs/breadboard/temperature-MCP9808-tessel.fzz](breadboard/te
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-MS5611.md
+++ b/docs/temperature-MS5611.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-SI7020.md
+++ b/docs/temperature-SI7020.md
@@ -78,7 +78,7 @@ Fritzing diagram: [docs/breadboard/temperature-SI7020-uno.fzz](breadboard/temper
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-SI7021.md
+++ b/docs/temperature-SI7021.md
@@ -78,7 +78,7 @@ Fritzing diagram: [docs/breadboard/multi-SI7021-uno.fzz](breadboard/multi-SI7021
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-TH02.md
+++ b/docs/temperature-TH02.md
@@ -56,7 +56,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-bmp085.md
+++ b/docs/temperature-bmp085.md
@@ -80,7 +80,7 @@ Fritzing diagram: [docs/breadboard/multi-bmp085.fzz](breadboard/multi-bmp085.fzz
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-ds18b20.md
+++ b/docs/temperature-ds18b20.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-htu21d.md
+++ b/docs/temperature-htu21d.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-lm335.md
+++ b/docs/temperature-lm335.md
@@ -63,7 +63,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-lm35.md
+++ b/docs/temperature-lm35.md
@@ -62,7 +62,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-max31850k.md
+++ b/docs/temperature-max31850k.md
@@ -68,7 +68,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-mpl115a2.md
+++ b/docs/temperature-mpl115a2.md
@@ -71,7 +71,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-mpl3115a2.md
+++ b/docs/temperature-mpl3115a2.md
@@ -74,7 +74,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-mpu6050.md
+++ b/docs/temperature-mpu6050.md
@@ -66,7 +66,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-sht31d.md
+++ b/docs/temperature-sht31d.md
@@ -67,7 +67,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-tmp102.md
+++ b/docs/temperature-tmp102.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/temperature-tmp36.md
+++ b/docs/temperature-tmp36.md
@@ -62,7 +62,7 @@ five.Board().on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-accelerometer.md
+++ b/docs/tinkerkit-accelerometer.md
@@ -78,7 +78,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-blink.md
+++ b/docs/tinkerkit-blink.md
@@ -56,7 +56,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-button.md
+++ b/docs/tinkerkit-button.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-combo.md
+++ b/docs/tinkerkit-combo.md
@@ -70,7 +70,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-continuous-servo.md
+++ b/docs/tinkerkit-continuous-servo.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-gyroscope.md
+++ b/docs/tinkerkit-gyroscope.md
@@ -51,7 +51,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-joystick.md
+++ b/docs/tinkerkit-joystick.md
@@ -57,7 +57,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-linear-pot.md
+++ b/docs/tinkerkit-linear-pot.md
@@ -58,7 +58,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-rotary.md
+++ b/docs/tinkerkit-rotary.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-thermistor.md
+++ b/docs/tinkerkit-thermistor.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-tilt.md
+++ b/docs/tinkerkit-tilt.md
@@ -62,7 +62,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/tinkerkit-touch.md
+++ b/docs/tinkerkit-touch.md
@@ -65,7 +65,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/toggle-switch.md
+++ b/docs/toggle-switch.md
@@ -75,7 +75,7 @@ board.on("ready", function() {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/docs/whisker.md
+++ b/docs/whisker.md
@@ -149,7 +149,7 @@ new five.Boards(["control", "nodebot"]).on("ready", function(boards) {
 ## License
 Copyright (c) 2012, 2013, 2014 Rick Waldron <waldron.rick@gmail.com>
 Licensed under the MIT license.
-Copyright (c) 2017 The Johnny-Five Contributors
+Copyright (c) 2018 The Johnny-Five Contributors
 Licensed under the MIT license.
 
 <!--remove-end-->

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -182,7 +182,8 @@ function RGB(opts) {
     blue: 255,
     intensity: 100,
     isAnode: opts.isAnode || false,
-    interval: null
+    interval: null,
+    isRunning: false
   };
 
   // red, green, and blue store the raw color set via .color()
@@ -191,6 +192,14 @@ function RGB(opts) {
     red: state.red,
     green: state.green,
     blue: state.blue
+  };
+
+  // state.prev records the last color set using color(),
+  // and is used to determine the new color when calling on() or pulse().
+  state.prev = {
+    red: 255,
+    green: 255,
+    blue: 255
   };
 
   priv.set(this, state);
@@ -207,7 +216,7 @@ function RGB(opts) {
     },
     isRunning: {
       get: function() {
-        return !!state.interval;
+        return !!(state.interval || state.isRunning);
       }
     },
     isAnode: {
@@ -399,40 +408,27 @@ RGB.prototype.color = function(red, green, blue) {
 
   this.update(update);
 
+  // Store colors to state.prev for future use by on() or pulse()
+  state.prev = update;
+
   return this;
 };
 
 RGB.prototype.on = function() {
   var state = priv.get(this);
-  var colors;
 
   // If it's not already on, we set them to the previous color
   if (!this.isOn) {
-    /* istanbul ignore next */
-    colors = state.prev || {
-      red: 255,
-      green: 255,
-      blue: 255
-    };
-
-    state.prev = null;
-
-    this.update(colors);
+    this.update(state.prev);
   }
 
   return this;
 };
 
 RGB.prototype.off = function() {
-  var state = priv.get(this);
-
-  // If it's already off, do nothing so the pervious state stays intact
+  // If it's already off, do nothing so the previous state stays intact
   /* istanbul ignore else */
   if (this.isOn) {
-    state.prev = RGB.colors.reduce(function(current, color) {
-      return (current[color] = state[color], current);
-    }.bind(this), {});
-
     this.update({
       red: 0,
       green: 0,
@@ -475,6 +471,55 @@ RGB.prototype.toggle = function() {
   return this[this.isOn ? "off" : "on"]();
 };
 
+/**
+ * pulse Fade the Led in and out in a loop with specified time
+ * @param  {number} duration Time in ms that a fade in/out will elapse
+ * @return {Led}
+ *
+ * - or -
+ *
+ * @param  {Object} val An Animation() segment config object
+ */
+
+RGB.prototype.pulse = function(duration, callback) {
+  var state = priv.get(this);
+
+  var currentColor = state.prev;
+
+  this.stop();
+
+  var options = {
+    duration: typeof duration === "number" ? duration : 1000,
+    keyFrames: [
+      {intensity: 0, color: currentColor},
+      {intensity: 100, color: currentColor}
+    ],
+    metronomic: true,
+    loop: true,
+    easing: "inOutSine",
+    onloop: function() {
+      /* istanbul ignore else */
+      if (typeof callback === "function") {
+        callback();
+      }
+    }
+  };
+
+  if (typeof duration === "object") {
+    Object.assign(options, duration);
+  }
+
+  if (typeof duration === "function") {
+    callback = duration;
+  }
+
+  state.isRunning = true;
+
+  state.animation = state.animation || new Animation(this);
+  state.animation.enqueue(options);
+  return this;
+};
+
 RGB.prototype.stop = function() {
   var state = priv.get(this);
 
@@ -488,6 +533,7 @@ RGB.prototype.stop = function() {
   }
 
   state.interval = null;
+  state.isRunning = false;
 
   return this;
 };
@@ -573,7 +619,7 @@ RGB.prototype[Animation.normalize] = function(keyFrames) {
  */
 
 RGB.prototype[Animation.render] = function(frames) {
-  return this.color(frames[0]);
+  return this.update(frames[0]);
 };
 
 /**

--- a/test/rgb.collection.js
+++ b/test/rgb.collection.js
@@ -291,21 +291,36 @@ exports["RGB.Collection"] = {
 
 
   "Animation.render": function(test) {
-    test.expect(1);
+    test.expect(4);
 
     var rgbs = new RGB.Collection([
       [1, 2, 3],
       [4, 5, 6],
     ]);
 
-    this.color = this.sandbox.stub(RGB.prototype, "color");
+    rgbs.each(function(rgb) {
+      this.sandbox.stub(rgb, "write");
+    }.bind(this));
 
     rgbs[Animation.render]([
       { red: 0xff, green: 0x00, blue: 0x00 },
       { red: 0x00, green: 0xff, blue: 0x00 },
     ]);
 
-    test.equal(this.color.callCount, 2);
+    test.equal(rgbs[0].write.callCount, 1);
+    test.deepEqual(rgbs[0].write.firstCall.args[0], {
+      red: 0xff,
+      green: 0x00,
+      blue: 0x00
+    });
+
+    test.equal(rgbs[1].write.callCount, 1);
+    test.deepEqual(rgbs[1].write.firstCall.args[0], {
+      red: 0x00,
+      green: 0xff,
+      blue: 0x00
+    });
+
     test.done();
   },
 };


### PR DESCRIPTION
Similar to the `LED.pulse()` method that runs an animation for a colorless LED, but implemented for a color LED.  I had to make more changes than I expected here, I'll annotate them inline.

Tested against Adafruit Circuit Playground Developer Edition in Code.org's App Lab+Maker Toolkit environment, against my local development machine.