### PR TITLE
Set fallback timeout to zero to use setInterval fallback 

### DIFF
--- a/lib/animation.js
+++ b/lib/animation.js
@@ -14,7 +14,10 @@ let temporal;
  * time (in ms) is reached we will fall back to setInterval which is less
  * accurate (by nanoseconds) but perfectly serviceable.
  **/
-let temporalTTL = 5000;
+// Code.org: Temporal is too CPU-intensive for our purposes.  We set this
+// value to zero so that Animation switches to a setInterval fallback mode
+// immediately, which works better for our purposes.
+let temporalTTL = 0;
 
 /**
  * Animation

--- a/test/servo.js
+++ b/test/servo.js
@@ -600,7 +600,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1000);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1000);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", () => {
@@ -670,7 +671,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1500);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1500);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", () => {
@@ -740,7 +742,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1500);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1500);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", () => {
@@ -810,7 +813,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1000);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1000);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", () => {
@@ -882,7 +886,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1000);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1000);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     this.servo.on("move:complete", () => {
@@ -911,7 +916,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1500);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1500);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
 
     test.done();
@@ -937,7 +943,8 @@ exports["Servo"] = {
     test.equal(state.animation.scaledDuration, 1500);
     test.equal(state.animation.startTime, 0);
     test.equal(state.animation.endTime, 1500);
-    test.equal(state.animation.fallBackTime, 5000);
+    // Code.org: Use animation fallback immediately
+    test.equal(state.animation.fallBackTime, 0);
     test.equal(state.animation.frameCount, 0);
     test.equal(state.animation.normalizedKeyFrames[0][1].value, 30);
 


### PR DESCRIPTION
Now that the code-dot-org/johnny-five is updated to the latest release from upstream, this PR re-implements a performance fix which causes Animations to always use the setTimeout fallback so `led.pulse()` isn't a CPU hog. See this [PR](https://github.com/code-dot-org/code-dot-org/pull/18694) for more context.

Before this PR update, the variable temporalTTL in animation.js is set to 5000. This variable is the max time that a temporal animation segment is run. When a temporal animation segment is running, it can push CPU utilization to 100%. After 5 seconds (the time that temporalTTL is assigned), the fall back to setInterval is used which is less accurate (by nanoseconds). For our purposes, the setInterval fallback mode is very serviceable and much better in terms of performance. 

Note - I tested this change using this code-dot-org [testing branch](https://github.com/code-dot-org/code-dot-org/tree/test-johnny-five-2) which includes the imports to the updated johnny-five and a change in webpack.js for johnny-five.

[jira ticket - Re-add the performance fix to use setTimeout fallback](https://codedotorg.atlassian.net/browse/SL-220)

## Testing
I modified tests in test/servo.js so that we are testing that animation.fallBackTime is set to 0.
I ran locally using grunt, and tests ran successfully.

<img width="761" alt="Screen Shot 2022-09-29 at 4 08 25 PM" src="https://user-images.githubusercontent.com/107423305/193145560-710b90b5-c85e-4f46-b54d-1e9d56451faf.png">

I then compared and recorded the performance of the board with the different temporalTTL settings.

With temporalTTL = 5000:
The performance of the led.blink and led.pulse commands vary - 

I ran led.blink for ~10 seconds: CPU usage is consistent throughout the running of program.

<img width="1189" alt="blink 10 sec with 5000" src="https://user-images.githubusercontent.com/107423305/195660774-73176459-7973-4ba5-afd2-8578da1e1dc7.png">

I then ran led.pulse for ~10 seconds: for the first 5 seconds after the program is run (from time 3s - 8s), led.pulse takes up much more CPU, then the setInterval fallback is used so that CPU usage decreases.
<img width="1195" alt="led pulse 10 sec with 5000 - start pulse at 3 s" src="https://user-images.githubusercontent.com/107423305/195661122-69b5b664-647e-41b0-82e2-3786a2d3bcbc.png">

I ran the program again, but started the program and then recorded its performance so that led.pulse began at -2 sec to see its CPU usage remain lower after the first 5 seconds the program is run:

<img width="1190" alt="led pulse 10 sec with 5000 start pulse at -2 s" src="https://user-images.githubusercontent.com/107423305/195661333-a2c5ea99-630f-4434-9a36-5e058b8f98f5.png">


With temporalTTL = 0:
After I set the variable temporalTTL from 5000 to 0, the performances of both led.blink and led.pulse commands are similar and consistent for the time recorded (~10 sec). 

I ran led.blink for ~10 seconds:

<img width="1200" alt="led link 10 sec with 0" src="https://user-images.githubusercontent.com/107423305/195662138-3f5e6a11-5095-4978-8ed4-161386e7ff5a.png">


I then ran led.pulse for ~10 seconds. Note that during the first 5 seconds, the CPU usage is lower than the CPU usage when the temporalTTL was set to 5000. And the CPU usage remains consistent throughout the 10 seconds.

<img width="1195" alt="led pulse 10 sec with 0" src="https://user-images.githubusercontent.com/107423305/195662190-c7846221-2dea-49ae-a589-21453db0281b.png">









