### PR TITLE
Add RGB pulse function

### DIFF
--- a/lib/animation.js
+++ b/lib/animation.js
@@ -375,13 +375,12 @@ class Animation extends Emitter {
         if (typeof right.value === "number" && typeof left.value === "number") {
           calcValue = (right.value - left.value) * tween.progress + left.value;
         } else {
-          // This is an Object
-          let keys = Object.keys(right.value);
-          // For example, right = right = { easing: "linear", value: {red: 255, green: 153, blue: 153}}
-          // keys are assigned ["red", "green", "blue"]
-          // Then caclValue will be assigned an object that contains the computed
+          // right.value is an Object
+          // For example, right = { easing: "linear", value: {red: 255, green: 153, blue: 153}}
+          // this.target[Animation.keys] are assigned ["red", "green", "blue"] from the RGB class
+          // Then calcValue will be assigned an object that contains the computed
           // RGB values, for example: {red: 178.13635605593453, green: 106.88181363356071, blue: 106.88181363356071}
-          calcValue = keys.reduce((accum, key) => {
+          calcValue = this.target[Animation.keys].reduce((accum, key) => {
             accum[key] = (right.value[key] - left.value[key]) * tween.progress + left.value[key];
             return accum;
           }, {});

--- a/lib/animation.js
+++ b/lib/animation.js
@@ -375,7 +375,13 @@ class Animation extends Emitter {
         if (typeof right.value === "number" && typeof left.value === "number") {
           calcValue = (right.value - left.value) * tween.progress + left.value;
         } else {
-          calcValue = this.target[Animation.keys].reduce((accum, key) => {
+          // This is an Object
+          let keys = Object.keys(right.value);
+          // For example, right = right = { easing: "linear", value: {red: 255, green: 153, blue: 153}}
+          // keys are assigned ["red", "green", "blue"]
+          // Then caclValue will be assigned an object that contains the computed
+          // RGB values, for example: {red: 178.13635605593453, green: 106.88181363356071, blue: 106.88181363356071}
+          calcValue = keys.reduce((accum, key) => {
             accum[key] = (right.value[key] - left.value[key]) * tween.progress + left.value[key];
             return accum;
           }, {});

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -277,7 +277,6 @@ class RGB {
 
   on() {
     const state = priv.get(this);
-    let colors;
 
     // If it's not already on, we set them to the previous color
     if (!this.isOn) {

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -494,13 +494,14 @@ class RGB {
 
 
 }
+
+RGB.colors = ["red", "green", "blue"];
+
 /**
  * For multi-property animation, must define
  * the keys to use for tween calculation.
  */
 RGB.prototype[Animation.keys] = RGB.colors;
-
-RGB.colors = ["red", "green", "blue"];
 
 RGB.ToScaledRGB = (intensity, colors) => {
   const scale = intensity / 100;

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -172,12 +172,22 @@ class RGB {
       intensity: 100,
       isAnode: options.isAnode || false,
       interval: null,
+      // isRunning is used to tracke whether an Animation is in progress
+      // Copying pattern used in led.js.
+      isRunning: false,
       // red, green, and blue store the raw color set via .color()
       // values takes state into account, such as on/off and intensity
       values: {
         red: 255,
         green: 255,
         blue: 255,
+      },
+      // state.prev records the last color set using color(),
+      // and is used to determine the new color when calling on() or pulse()
+      prev: {
+        red: 255,
+        green: 255,
+        blue: 255
       }
     };
 
@@ -191,7 +201,7 @@ class RGB {
       },
       isRunning: {
         get() {
-          return !!state.interval;
+          return !!state.interval || state.isRunning;
         }
       },
       isAnode: {
@@ -259,6 +269,9 @@ class RGB {
 
     this.update(update);
 
+    // Store colors to state.prev for future use by on() or pulse()
+    state.prev = update;
+
     return this;
   }
 
@@ -269,15 +282,7 @@ class RGB {
     // If it's not already on, we set them to the previous color
     if (!this.isOn) {
       /* istanbul ignore next */
-      colors = state.prev || {
-        red: 255,
-        green: 255,
-        blue: 255
-      };
-
-      state.prev = null;
-
-      this.update(colors);
+      this.update(state.prev);
     }
 
     return this;
@@ -286,7 +291,7 @@ class RGB {
   off() {
     const state = priv.get(this);
 
-    // If it's already off, do nothing so the pervious state stays intact
+    // If it's already off, do nothing so the previous state stays intact
     /* istanbul ignore else */
     if (this.isOn) {
       state.prev = RGB.colors.reduce((current, color) => (current[color] = state[color], current), {});
@@ -329,6 +334,61 @@ class RGB {
 
   toggle() {
     return this[this.isOn ? "off" : "on"]();
+  }
+
+  /**
+   * pulse Fade the RGB in and out in a loop with specified time
+   * @param  {number} duration Time in ms that a fade in/out will elapse
+   * @return {RGB}
+   *
+   * - or -
+   *
+   * @param  {Object} val An Animation() segment config object
+   */
+
+  // rgb pulse function similar to led pulse function
+  // uses state.prev for the current color
+  pulse(duration, callback) {
+    const state = priv.get(this);
+    var currentColor = state.prev;
+    this.stop();
+
+    const options = {
+      duration: typeof duration === "number" ? duration : 1000,
+      keyFrames: [
+        {
+          color: currentColor,
+          intensity: 0
+        },
+        {
+          color: currentColor,
+          intensity: 100
+        }
+      ],
+      metronomic: true,
+      loop: true,
+      easing: "inOutSine",
+      onloop() {
+        /* istanbul ignore else */
+        if (typeof callback === "function") {
+          callback();
+        }
+      }
+    };
+
+    if (typeof duration === "object") {
+      Object.assign(options, duration);
+    }
+
+    if (typeof duration === "function") {
+      callback = duration;
+    }
+
+    state.isRunning = true;
+
+    state.animation = state.animation || new Animation(this);
+    state.animation.enqueue(options);
+    return this;
   }
 
   stop() {


### PR DESCRIPTION
Now that the code-dot-org/johnny-five is updated to the latest release from upstream, this PR re-implements the `rgb.pulse` function in the `RGB` class. Refer to this [PR](https://github.com/code-dot-org/johnny-five/pull/10) for the past implementation of this function.

The implementation of pulse was very similar to past implementation by @islemaster. However I kept the upstream implementation of `Animation.render` in `rgb.js`. 
Also, in `rgb.js` I had to move the assignment of Animation.keys after RGB.colors was defined. When I first implemented the `pulse` function, I received an error due to the fact that `Animation.keys` was not defined correctly.
Looking in `rgb.js`, the reason was that `RGB.colors` was not assigned yet. So I placed the `RGB.colors` assignment before the `Animation.keys` was assigned to it. I also added clarifying comments in the `tweenedValues` function where an error was being thrown before the fix.

Comments are embedded for more details of implementation.

## Links
[jira - Re-add LED pulse to johnny-five](https://codedotorg.atlassian.net/browse/SL-221)

## Testing
I ran the johnny-five tests locally using `grunt`:

<img width="736" alt="Screen Shot 2022-10-14 at 2 05 56 PM" src="https://user-images.githubusercontent.com/107423305/195922269-84790e2b-827a-4f7a-ac27-587610b7fade.png">

I also tested locally with the Circuit Playground. Videos are below.
This is a program that toggles between `rgb.pulse` and `rgb.blink`:

https://user-images.githubusercontent.com/107423305/195685506-4774f2cb-652c-4ec1-9b9e-11d665b1b730.mp4

This is a program that shows both 'rgb.pulse` and `led.pulse`:

https://user-images.githubusercontent.com/107423305/195687299-181f5825-8ddd-4a68-ba9c-233dbea30416.mp4


