### PR TITLE
Update version to 2.1.0-cdo.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@code-dot-org/johnny-five",
   "description": "Code.org fork of rwaldron/johnny-five: The JavaScript Robotics and Hardware Programming Framework. Use with: Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!",
-  "version": "2.1.0-cdo.0",
+  "version": "2.1.0-cdo.1",
   "homepage": "https://johnny-five.io",
   "author": "Rick Waldron <waldron.rick@gmail.com>",
   "keywords": [


### PR DESCRIPTION
This PR updates the version of code-dot-org/johnny-five to 2.1.0-cdo.1.

After updating the code-dot-org/johnny-five to the latest release from upstream, we re-implemented the Code.org customizations based on this [investigation](https://codedotorg.atlassian.net/browse/SL-14).
In particular, the changes were:
- Setting a variable in `Animations.js` so that the `setTimeout` fallback is always used by the `pulse` functions - [PR](https://github.com/code-dot-org/johnny-five/pull/13)
- Adding a `pulse` function in `rgb.js`- [PR](https://github.com/code-dot-org/johnny-five/pull/15)
- Rounding scaled sensor values - [PR](https://github.com/code-dot-org/johnny-five/pull/17)

At first, I did not think that the third Code.org customization was necessary because of changes I observed in `lib/sensor.js` since all of the customizations were added. In particular,  within `eventProcessing`, once the `median` is computed, it is rounded and assigned to `roundMedian` at [line 122](https://github.com/code-dot-org/johnny-five/blob/main/lib/sensor.js#L122) but is not rounded in [johnny-five-deprecated](https://github.com/code-dot-org/johnny-five-deprecated/blob/main/lib/sensor.js#L117).

However, when `setScale` is called by the user, the emitted value is first "selected" by the `median` function and then scaled. So I added the third customization in this [PR](https://github.com/code-dot-org/johnny-five/pull/17) which includes more detailed discussion.

At this point, the Code.org customizations have been completed so we are ready to update the version from 2.1.0-cdo.0 to 2.1.0-cdo.1.
