### PR TITLE
Round scaled sensor values

### DIFF
--- a/lib/sensor.js
+++ b/lib/sensor.js
@@ -195,7 +195,7 @@ class Sensor extends Withinable {
       },
       scaled: {
         get() {
-          let mapped, constrain, rounded;
+          let mapped, constrain;
 
           if (state.scale && raw !== null) {
             if (options.type === "digital") {
@@ -206,8 +206,7 @@ class Sensor extends Withinable {
 
             mapped = Fn.fmap(raw, this.range[0], this.range[1], state.scale[0], state.scale[1]);
             // Code.org: round scaled sensor values
-            rounded = Math.round(mapped);
-            constrain = Fn.constrain(rounded, state.scale[0], state.scale[1]);
+            constrain = Fn.constrain(Math.round(mapped), state.scale[0], state.scale[1]);
 
             return constrain;
           }

--- a/lib/sensor.js
+++ b/lib/sensor.js
@@ -195,8 +195,7 @@ class Sensor extends Withinable {
       },
       scaled: {
         get() {
-          let mapped;
-          let constrain;
+          let mapped, constrain, rounded;
 
           if (state.scale && raw !== null) {
             if (options.type === "digital") {
@@ -206,7 +205,9 @@ class Sensor extends Withinable {
             }
 
             mapped = Fn.fmap(raw, this.range[0], this.range[1], state.scale[0], state.scale[1]);
-            constrain = Fn.constrain(mapped, state.scale[0], state.scale[1]);
+            // Code.org: round scaled sensor values
+            rounded = Math.round(mapped);
+            constrain = Fn.constrain(rounded, state.scale[0], state.scale[1]);
 
             return constrain;
           }


### PR DESCRIPTION
Now that the code-dot-org/johnny-five is updated to the latest release from upstream, this PR re-implements rounding scaled sensor values proposed as Change #1 in this [investigation](https://codedotorg.atlassian.net/browse/SL-14).

When I first investigated this last customization, I ran an App Lab program to see if sensor values were already displayed as integer values using the updated johnny-five package, and they are. In addition to this observation, I also noted that in `lib/sensor.js` within `eventProcessing`, once the `median` is computed, it is rounded and assigned to `roundMedian` at [line 122](https://github.com/code-dot-org/johnny-five/blob/main/lib/sensor.js#L122) but is not rounded in [johnny-five-deprecated](https://github.com/code-dot-org/johnny-five-deprecated/blob/main/lib/sensor.js#L117). Thus, I thought that this third customization was not necessary.

However, after running the tests in `PlaygroundComponentsTest.js` in @code-dot-org, I saw that the setScale tests failed which helped me understand that the scaling occurs after the value is reached from the `eventProcessing` function. 

I confirmed that this rounding is necessary with the following program.
![Screen Shot 2022-10-19 at 12 41 15 PM](https://user-images.githubusercontent.com/107423305/196765606-e6226213-2e67-4a76-9cdc-f883e71bad1a.png)

Before the customization:

https://user-images.githubusercontent.com/107423305/196768763-1b0a0c69-9300-45b4-8b27-b68c39980673.mp4


After the customization:

https://user-images.githubusercontent.com/107423305/196768858-f5f5be59-bee5-4621-a998-c3dee3ffa462.mp4

I looked into why the sensor values in the johnny-five-deprecated package are still displayed as integer values despite not having the `median` rounded. The comment above the function `median` explains that to reduce the noise in sensor readings, collected samples from the sensor are collected and then sorted. The value at the center is selected for the final value emitted and because there are many duplicate numbers, the result is almost always an integer even where there are an even number of values in the sample. 
However, I am happy to see they added the `Math.round` just in case!

<img width="893" alt="Screen Shot 2022-10-19 at 3 03 42 PM" src="https://user-images.githubusercontent.com/107423305/196792725-f31de244-e506-4524-b643-141bd6c85f1a.png">

I posted a [PR](https://github.com/code-dot-org/johnny-five/pull/16) to update the johnny-five version to 2.1.0-cdo.1. However, I will first merge this change, and then update the version of the package. 

## Links
[jira ticket - Re-add rounded scaled sensor values](https://codedotorg.atlassian.net/browse/SL-222)

## Testing
I ran the @code-dot-org unit tests in files that import johnny-five. In particular, `PlaygroundComponents.js` had a handful of unit tests that specifically tested the `setScale` function.