### PR TITLE
Fix sensor.scale unit test 

### DIFF
--- a/test/sensor.js
+++ b/test/sensor.js
@@ -1111,8 +1111,9 @@ exports["Sensor - Analog"] = {
 
     // Ensure sensors may return float values
     this.sensor.scale([0, 102.3]);
+    // Code.org: Scaled sensor values are rounded
     this.sensor.once("change", function() {
-      test.equal(this.value, 1.2000000476837158);
+      test.equal(this.value, 1);
     });
     callback(12);
     this.clock.tick(25);


### PR DESCRIPTION
This PR fixes a unit test that confirms that scaled sensor values are rounded.  View the PR which implemented this customization [here](https://github.com/code-dot-org/johnny-five/pull/17).
Note that tests in johnny-five can be run using `grunt`. 

<img width="1150" alt="Screen Shot 2022-10-19 at 9 14 10 PM" src="https://user-images.githubusercontent.com/107423305/196840176-0f84fc6f-aa0d-4c04-bf62-9ae933c503f3.png">

