### PR TITLE
Revert "Update version to 2.1.0-cdo.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@code-dot-org/johnny-five",
   "description": "Code.org fork of rwaldron/johnny-five: The JavaScript Robotics and Hardware Programming Framework. Use with: Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!",
-  "version": "2.1.0-cdo.1",
+  "version": "2.1.0-cdo.0",
   "homepage": "https://johnny-five.io",
   "author": "Rick Waldron <waldron.rick@gmail.com>",
   "keywords": [


### PR DESCRIPTION
Reverts code-dot-org/johnny-five#16
I omitted a unit test fix so this PR reverts the update to the newest version 2.1.0-cdo.1
Then I will merge [this PR](https://github.com/code-dot-org/johnny-five/pull/18) which fixes one johnny-five unit test.