### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,29 +83,8 @@ This is the most typical use case for @code-dot-org/johnny-five fork development
 
 [Apps (aka Code Studio)](https://github.com/code-dot-org/code-dot-org/tree/staging/apps) is a set of apps which installs and references this package. You can run the dashboard locally from the apps directory using `bin/dashboard-server` ([setup reference](https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md))
 
-Below are two options for local development and testing.
 
-1. Use [yarn link](https://classic.yarnpkg.com/en/docs/cli/link) 
-
-```
-cd {@code-dot-org/johnny-five repo directory}
-yarn link
-cd {code-dot-org repo directory}/apps
-yarn link @code-dot-org/johnny-five
-```
-
-When you are finished testing locally, you must undo yarn link in the reverse order:
-
-```
-cd {code-dot-org repo directory}/apps
-yarn unlink @code-dot-org/johnny-five
-cd {@code-dot-org/johnny-five repo directory}
-yarn unlink
-```
-
-The advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally to view and interact with the App lab with the enabled Maker Toolkit.
-
-2. [yarn add](https://classic.yarnpkg.com/lang/en/docs/cli/add/):
+You can use [`yarn add`](https://classic.yarnpkg.com/lang/en/docs/cli/add/) for local development and testing.
 
 ```
 cd {code-dot-org repo directory}/apps
@@ -114,10 +93,9 @@ yarn add <file-path-to-local-folder>
 
 When you are finished testing locally, you can run `yarn @code-dot-org/johnny-five` to install the npm package instead of the local package. 
 
+Note that a copy of the local johnny-five package was added to your node_modules directory so that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules. Thus, you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. 
 
-An advantage of using `yarn add` is that when you run the Apps dashboard server locally, you will be able access the App lab with the enabled Maker Toolkit using your browser (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
-
-For both options, Apps will now reference your local @code-dot-org/johnny-five repository rather than the npm package. If you make local changes to your repo, you can rebuild apps (via `yarn run build` in code-dot-org/apps) to communicate these changes to apps.
+In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
 
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ _Artwork by [Mike Sgier](http://msgierillustration.com)_
 
 _This is the [Code.org](https://code.org) fork of johnny-five.  Please [check out the main project here!](https://github.com/rwaldron/johnny-five)_
 
-This project was forked to provide better support for the [Adafruit Circuit Playground](https://learn.adafruit.com/introducing-circuit-playground/overview) which is used in the Code.org curriculum. The project was updated to the latest release of its upstream in September 2022, and Code.org customizations were then re-implemented.
+This project was forked in 2017 to provide better support for the [Adafruit Circuit Playground](https://learn.adafruit.com/introducing-circuit-playground/overview) which is used in the Code.org curriculum. The project was updated to the latest release of its upstream in September 2022, and Code.org customizations were then re-implemented.
+
+#### Source Code:
+
+``` bash
+git clone https://github.com/code-dot-org/johnny-five
+
+cd johnny-five
+
+npm install
+```
 
 ## Building and testing with apps
 
@@ -93,7 +103,7 @@ cd {@code-dot-org/johnny-five repo directory}
 yarn unlink
 ```
 
-For this first option, the advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally.
+The advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally.
 
 2. [yarn add](https://classic.yarnpkg.com/lang/en/docs/cli/add/):
 
@@ -105,9 +115,18 @@ yarn add <file-path-to-local-folder>
 When you are finished testing locally, you can run `yarn @code-dot-org/johnny-five` to install the npm package instead of the local package. 
 
 
-For this second option, an advantage is that after you run the dashboard-server, you will be able to use your browser locally (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
+An advantage of using `yarn add` is that after you run the dashboard-server, you will be able to use your browser locally (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
 
 For both options, Apps will now reference your local @code-dot-org/johnny-five repository rather than the npm package. If you make local changes to your repo, you can rebuild apps (via `yarn run build` in code-dot-org/apps) to communicate these changes to apps.
+
+
+## Testing
+You can lint and test your code (unit tests included in `test/`) using the `grunt` command. Remember to add or update unit tests for any new or changed functionality.
+
+There are additional tests in Apps within apps/test/unit/lib/kits/boards/circuitPlayground and apps/test/unit/lib/kits/boards that you can run locally to test any new updates within johnny-five. Refer to [testing.md](https://github.com/code-dot-org/code-dot-org/blob/staging/TESTING.md).
+
+## Updating README
+If you'd like to make changes to the readme contents, please make them in the tpl/.readme.md file. Then generated the markdown with: `grunt examples`.
 
 <!-- End of Code.org customizations -->
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,51 @@ _Artwork by [Mike Sgier](http://msgierillustration.com)_
 <!-- No appveyor or gitter -->
 
 _This is the [Code.org](https://code.org) fork of johnny-five.  Please [check out the main project here!](https://github.com/rwaldron/johnny-five)_
+
+This project was forked to provide better support for the [Adafruit Circuit Playground](https://learn.adafruit.com/introducing-circuit-playground/overview) which is used in the Code.org curriculum. The project was updated to the latest release of its upstream in September 2022, and Code.org customizations were then re-implemented.
+
+## Building and testing with apps
+
+This is the most typical use case for @code-dot-org/johnny-five fork development.
+
+[Apps (aka Code Studio)](https://github.com/code-dot-org/code-dot-org/tree/staging/apps) is a set of apps which installs and references this package. 
+
+Below are two options for local development and testing.
+
+1. Use [yarn link](https://classic.yarnpkg.com/en/docs/cli/link) 
+
+```
+cd {@code-dot-org/johnny-five repo directory}
+yarn link
+cd {code-dot-org repo directory}/apps
+yarn link @code-dot-org/johnny-five
+```
+
+When you are finished testing locally, you must undo yarn link in the reverse order:
+
+```
+cd {code-dot-org repo directory}/apps
+yarn unlink @code-dot-org/johnny-five
+cd {@code-dot-org/johnny-five repo directory}
+yarn unlink
+```
+
+For this first option, the advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally.
+
+2. [yarn add](https://classic.yarnpkg.com/lang/en/docs/cli/add/):
+
+```
+cd {code-dot-org repo directory}/apps
+yarn add <file-path-to-local-folder> 
+```
+
+When you are finished testing locally, you can run `yarn @code-dot-org/johnny-five` to install the npm package instead of the local package. 
+
+
+For this second option, an advantage is that after you run the dashboard-server, you will be able to use your browser locally (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
+
+For both options, Apps will now reference your local @code-dot-org/johnny-five repository rather than the npm package. If you make local changes to your repo, you can rebuild apps (via `yarn run build` in code-dot-org/apps) to communicate these changes to apps.
+
 <!-- End of Code.org customizations -->
 
 **Johnny-Five is an Open Source, Firmata Protocol based, IoT and Robotics programming framework, developed by the [Nodebots](https://twitter.com/nodebots) Community. Johnny-Five programs can be written for Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!**

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ npm install
 
 This is the most typical use case for @code-dot-org/johnny-five fork development.
 
-[Apps (aka Code Studio)](https://github.com/code-dot-org/code-dot-org/tree/staging/apps) is a set of apps which installs and references this package. 
+[Apps (aka Code Studio)](https://github.com/code-dot-org/code-dot-org/tree/staging/apps) is a set of apps which installs and references this package. You can run the dashboard locally from the apps directory using `bin/dashboard-server` ([setup reference](https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md))
 
 Below are two options for local development and testing.
 
@@ -103,7 +103,7 @@ cd {@code-dot-org/johnny-five repo directory}
 yarn unlink
 ```
 
-The advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally.
+The advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally to view and interact with the App lab with the enabled Maker Toolkit.
 
 2. [yarn add](https://classic.yarnpkg.com/lang/en/docs/cli/add/):
 
@@ -115,7 +115,7 @@ yarn add <file-path-to-local-folder>
 When you are finished testing locally, you can run `yarn @code-dot-org/johnny-five` to install the npm package instead of the local package. 
 
 
-An advantage of using `yarn add` is that after you run the dashboard-server, you will be able to use your browser locally (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
+An advantage of using `yarn add` is that when you run the Apps dashboard server locally, you will be able access the App lab with the enabled Maker Toolkit using your browser (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
 
 For both options, Apps will now reference your local @code-dot-org/johnny-five repository rather than the npm package. If you make local changes to your repo, you can rebuild apps (via `yarn run build` in code-dot-org/apps) to communicate these changes to apps.
 

--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -71,6 +71,8 @@ For both options, Apps will now reference your local @code-dot-org/johnny-five r
 ## Testing
 You can lint and test your code (unit tests included in `test/`) using the `grunt` command. Remember to add or update unit tests for any new or changed functionality.
 
+There are additional tests in Apps within apps/test/unit/lib/kits/boards/circuitPlayground and apps/test/unit/lib/kits/boards that you can run locally to test any new updates within johnny-five. Refer to [testing.md](https://github.com/code-dot-org/code-dot-org/blob/staging/TESTING.md).
+
 ## Updating README
 If you'd like to make changes to the readme contents, please make them in the tpl/.readme.md file. Then generated the markdown with: `grunt examples`.
 

--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -13,7 +13,17 @@ _Artwork by [Mike Sgier](http://msgierillustration.com)_
 
 _This is the [Code.org](https://code.org) fork of johnny-five.  Please [check out the main project here!](https://github.com/rwaldron/johnny-five)_
 
-This project was forked to provide better support for the [Adafruit Circuit Playground](https://learn.adafruit.com/introducing-circuit-playground/overview) which is used in the Code.org curriculum. The project was updated to the latest release of its upstream in September 2022, and Code.org customizations were then re-implemented.
+This project was forked in 2017 to provide better support for the [Adafruit Circuit Playground](https://learn.adafruit.com/introducing-circuit-playground/overview) which is used in the Code.org curriculum. The project was updated to the latest release of its upstream in September 2022, and Code.org customizations were then re-implemented.
+
+#### Source Code:
+
+``` bash
+git clone https://github.com/code-dot-org/johnny-five
+
+cd johnny-five
+
+npm install
+```
 
 ## Building and testing with apps
 
@@ -41,7 +51,7 @@ cd {@code-dot-org/johnny-five repo directory}
 yarn unlink
 ```
 
-For this first option, the advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally.
+The advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally.
 
 2. [yarn add](https://classic.yarnpkg.com/lang/en/docs/cli/add/):
 
@@ -53,9 +63,16 @@ yarn add <file-path-to-local-folder>
 When you are finished testing locally, you can run `yarn @code-dot-org/johnny-five` to install the npm package instead of the local package. 
 
 
-For this second option, an advantage is that after you run the dashboard-server, you will be able to use your browser locally (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
+An advantage of using `yarn add` is that after you run the dashboard-server, you will be able to use your browser locally (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
 
 For both options, Apps will now reference your local @code-dot-org/johnny-five repository rather than the npm package. If you make local changes to your repo, you can rebuild apps (via `yarn run build` in code-dot-org/apps) to communicate these changes to apps.
+
+
+## Testing
+You can lint and test your code (unit tests included in `test/`) using the `grunt` command. Remember to add or update unit tests for any new or changed functionality.
+
+## Updating README
+If you'd like to make changes to the readme contents, please make them in the tpl/.readme.md file. Then generated the markdown with: `grunt examples`.
 
 <!-- End of Code.org customizations -->
 

--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -29,7 +29,7 @@ npm install
 
 This is the most typical use case for @code-dot-org/johnny-five fork development.
 
-[Apps (aka Code Studio)](https://github.com/code-dot-org/code-dot-org/tree/staging/apps) is a set of apps which installs and references this package. 
+[Apps (aka Code Studio)](https://github.com/code-dot-org/code-dot-org/tree/staging/apps) is a set of apps which installs and references this package. You can run the dashboard locally from the apps directory using `bin/dashboard-server` ([setup reference](https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md))
 
 Below are two options for local development and testing.
 
@@ -51,7 +51,7 @@ cd {@code-dot-org/johnny-five repo directory}
 yarn unlink
 ```
 
-The advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally.
+The advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally to view and interact with the App lab with the enabled Maker Toolkit.
 
 2. [yarn add](https://classic.yarnpkg.com/lang/en/docs/cli/add/):
 
@@ -63,7 +63,7 @@ yarn add <file-path-to-local-folder>
 When you are finished testing locally, you can run `yarn @code-dot-org/johnny-five` to install the npm package instead of the local package. 
 
 
-An advantage of using `yarn add` is that after you run the dashboard-server, you will be able to use your browser locally (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
+An advantage of using `yarn add` is that when you run the Apps dashboard server locally, you will be able access the App lab with the enabled Maker Toolkit using your browser (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
 
 For both options, Apps will now reference your local @code-dot-org/johnny-five repository rather than the npm package. If you make local changes to your repo, you can rebuild apps (via `yarn run build` in code-dot-org/apps) to communicate these changes to apps.
 

--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -31,29 +31,8 @@ This is the most typical use case for @code-dot-org/johnny-five fork development
 
 [Apps (aka Code Studio)](https://github.com/code-dot-org/code-dot-org/tree/staging/apps) is a set of apps which installs and references this package. You can run the dashboard locally from the apps directory using `bin/dashboard-server` ([setup reference](https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md))
 
-Below are two options for local development and testing.
 
-1. Use [yarn link](https://classic.yarnpkg.com/en/docs/cli/link) 
-
-```
-cd {@code-dot-org/johnny-five repo directory}
-yarn link
-cd {code-dot-org repo directory}/apps
-yarn link @code-dot-org/johnny-five
-```
-
-When you are finished testing locally, you must undo yarn link in the reverse order:
-
-```
-cd {code-dot-org repo directory}/apps
-yarn unlink @code-dot-org/johnny-five
-cd {@code-dot-org/johnny-five repo directory}
-yarn unlink
-```
-
-The advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally to view and interact with the App lab with the enabled Maker Toolkit.
-
-2. [yarn add](https://classic.yarnpkg.com/lang/en/docs/cli/add/):
+You can use [`yarn add`](https://classic.yarnpkg.com/lang/en/docs/cli/add/) for local development and testing.
 
 ```
 cd {code-dot-org repo directory}/apps
@@ -62,10 +41,9 @@ yarn add <file-path-to-local-folder>
 
 When you are finished testing locally, you can run `yarn @code-dot-org/johnny-five` to install the npm package instead of the local package. 
 
+Note that a copy of the local johnny-five package was added to your node_modules directory so that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules. Thus, you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. 
 
-An advantage of using `yarn add` is that when you run the Apps dashboard server locally, you will be able access the App lab with the enabled Maker Toolkit using your browser (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
-
-For both options, Apps will now reference your local @code-dot-org/johnny-five repository rather than the npm package. If you make local changes to your repo, you can rebuild apps (via `yarn run build` in code-dot-org/apps) to communicate these changes to apps.
+In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
 
 
 ## Testing

--- a/tpl/.readme.md
+++ b/tpl/.readme.md
@@ -12,6 +12,51 @@ _Artwork by [Mike Sgier](http://msgierillustration.com)_
 <!-- No appveyor or gitter -->
 
 _This is the [Code.org](https://code.org) fork of johnny-five.  Please [check out the main project here!](https://github.com/rwaldron/johnny-five)_
+
+This project was forked to provide better support for the [Adafruit Circuit Playground](https://learn.adafruit.com/introducing-circuit-playground/overview) which is used in the Code.org curriculum. The project was updated to the latest release of its upstream in September 2022, and Code.org customizations were then re-implemented.
+
+## Building and testing with apps
+
+This is the most typical use case for @code-dot-org/johnny-five fork development.
+
+[Apps (aka Code Studio)](https://github.com/code-dot-org/code-dot-org/tree/staging/apps) is a set of apps which installs and references this package. 
+
+Below are two options for local development and testing.
+
+1. Use [yarn link](https://classic.yarnpkg.com/en/docs/cli/link) 
+
+```
+cd {@code-dot-org/johnny-five repo directory}
+yarn link
+cd {code-dot-org repo directory}/apps
+yarn link @code-dot-org/johnny-five
+```
+
+When you are finished testing locally, you must undo yarn link in the reverse order:
+
+```
+cd {code-dot-org repo directory}/apps
+yarn unlink @code-dot-org/johnny-five
+cd {@code-dot-org/johnny-five repo directory}
+yarn unlink
+```
+
+For this first option, the advantages of using `yarn link` is that changes in @code-dot-org/johnny-five are automatically transferred to @code-dot-org/code-dot-org/apps/node_modules and there are no local changes to package.json or yarn.lock. The disadvantage is that after you run the dashboard-server, you will need to use the Code.org Maker App locally.
+
+2. [yarn add](https://classic.yarnpkg.com/lang/en/docs/cli/add/):
+
+```
+cd {code-dot-org repo directory}/apps
+yarn add <file-path-to-local-folder> 
+```
+
+When you are finished testing locally, you can run `yarn @code-dot-org/johnny-five` to install the npm package instead of the local package. 
+
+
+For this second option, an advantage is that after you run the dashboard-server, you will be able to use your browser locally (no need to use the Maker app). The disadvantages of using `yarn add` are that changes in @code-dot-org/johnny-five are not automatically transferred to @code-dot-org/code-dot-org/apps/node_modules so that you must run `yarn add <file-path-to-local-folder>` again after any changes in the local johnny-five package. In addition, there are changes to your package.json and yarn.lock locally that you do not want to commit.
+
+For both options, Apps will now reference your local @code-dot-org/johnny-five repository rather than the npm package. If you make local changes to your repo, you can rebuild apps (via `yarn run build` in code-dot-org/apps) to communicate these changes to apps.
+
 <!-- End of Code.org customizations -->
 
 **Johnny-Five is an Open Source, Firmata Protocol based, IoT and Robotics programming framework, developed by the [Nodebots](https://twitter.com/nodebots) Community. Johnny-Five programs can be written for Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!**


### PR DESCRIPTION
This PR updates the README to include information for contributors on how to build and test new features or bug fixes locally for @code-dot-org/johnny-five.

During testing and development, I used `yarn add` instead of `yarn link` because `yarn link` causes errors described in detail in [this doc](https://docs.google.com/document/d/1uEAdbRKLYplBU-6frA8A2t8fiKuFlIzNxprloM7CvIQ/edit?usp=sharing). This issue is intriguing and I would like to investigate this further. However, I do recommend using `yarn add` since it works consistently despite a couple inconveniences described in the README. 

[jira ticket](https://codedotorg.atlassian.net/jira/software/c/projects/SL/issues/SL-340)