### PR TITLE
Fix rgb pulse function

### DIFF
--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -180,7 +180,7 @@ class RGB {
       values: {
         red: 255,
         green: 255,
-        blue: 255,
+        blue: 255
       },
       // state.prev records the last color set using color(),
       // and is used to determine the new color when calling on() or pulse()
@@ -488,7 +488,7 @@ class RGB {
    */
 
   [Animation.render](frames) {
-    return this.color(frames[0]);
+    return this.update(frames[0]);
   }
 
 

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -269,7 +269,7 @@ class RGB {
 
     this.update(update);
 
-    // Store colors to state.prev for future use by on() or pulse()
+    // Store colors to state.prev for future use by on()
     state.prev = update;
 
     return this;

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -293,8 +293,6 @@ class RGB {
     // If it's already off, do nothing so the previous state stays intact
     /* istanbul ignore else */
     if (this.isOn) {
-      state.prev = RGB.colors.reduce((current, color) => (current[color] = state[color], current), {});
-
       this.update({
         red: 0,
         green: 0,

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -172,7 +172,7 @@ class RGB {
       intensity: 100,
       isAnode: options.isAnode || false,
       interval: null,
-      // isRunning is used to tracke whether an Animation is in progress
+      // isRunning is used to track whether an Animation is in progress
       // Copying pattern used in led.js.
       isRunning: false,
       // red, green, and blue store the raw color set via .color()
@@ -350,6 +350,8 @@ class RGB {
   pulse(duration, callback) {
     const state = priv.get(this);
     var currentColor = state.prev;
+
+    // Avoid traffic jams
     this.stop();
 
     const options = {
@@ -402,7 +404,7 @@ class RGB {
       state.animation.stop();
     }
 
-    state.interval = null;
+    state.interval = null; // sets isRunning to false
 
     return this;
   }

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -288,8 +288,6 @@ class RGB {
   }
 
   off() {
-    const state = priv.get(this);
-
     // If it's already off, do nothing so the previous state stays intact
     /* istanbul ignore else */
     if (this.isOn) {


### PR DESCRIPTION
This is a follow up to [this PR](https://github.com/code-dot-org/johnny-five/pull/15) which added the pulse function to the RGB class in the updated `codedotorg/johnny-five` package. 

Currently, the `pulse` function in the RGB class is buggy - when `pulse` is called multiple times consecutively on an RGB, the light emitted gradually decreases to 0. See example below:


https://user-images.githubusercontent.com/107423305/204841830-cc909dff-42be-4e7e-bbee-9302cdb9834a.mp4


In addition, when `pulse` is called and then `off` is called afterwards on an RGB, the light emitted also decreases to 0.
Screencast below:


https://user-images.githubusercontent.com/107423305/204841873-63b4cea1-1105-408a-80cf-86a98cba0b60.mp4

To fix the first issue, `update` is called instead of `color` within `Animation.render` in `lib/led/rgb.js`. More details are included in the embedded comment.

To fix the second issue, I removed the reassignment of `state.prev` within `off` in the same file. More details are included in the second embedded comment.

Screencast videos after the updates:
`pulse` called repeatedly on an RGB:

https://user-images.githubusercontent.com/107423305/204843501-ab676e63-7dbf-4c6c-8f37-015d86b927de.mp4



`pulse` called and then `off` called on an RGB repeatedly:



https://user-images.githubusercontent.com/107423305/204843546-b3672ec2-11a4-4b5c-b5af-efb59422cf62.mp4

## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-389)
