### PR TITLE
Another rgb pulse revision, fix unit tests, update package version

### DIFF
--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -215,6 +215,7 @@ class RGB {
         }
       },
       update: {
+        writable: true,
         value(colors) {
           const state = priv.get(this);
 

--- a/lib/led/rgb.js
+++ b/lib/led/rgb.js
@@ -282,6 +282,9 @@ class RGB {
     if (!this.isOn) {
       /* istanbul ignore next */
       this.update(state.prev);
+    } else if (state.isRunning) {
+      this.stop();
+      this.update(state.prev);
     }
 
     return this;
@@ -486,7 +489,9 @@ class RGB {
    */
 
   [Animation.render](frames) {
-    return this.update(frames[0]);
+    const state = priv.get(this);
+    state.value = frames[0];
+    return this.update(state.value);
   }
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@code-dot-org/johnny-five",
   "description": "Code.org fork of rwaldron/johnny-five: The JavaScript Robotics and Hardware Programming Framework. Use with: Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!",
-  "version": "2.1.0-cdo.1",
+  "version": "2.1.0-cdo.2",
   "homepage": "https://johnny-five.io",
   "author": "Rick Waldron <waldron.rick@gmail.com>",
   "keywords": [

--- a/test/rgb.collection.js
+++ b/test/rgb.collection.js
@@ -291,22 +291,18 @@ exports["RGB.Collection"] = {
 
 
   "Animation.render": function(test) {
-    test.expect(1);
+    test.expect(3);
 
-    const rgbs = new RGB.Collection([
-      [1, 2, 3],
-      [4, 5, 6],
-    ]);
-
-    this.color = this.sandbox.stub(RGB.prototype, "color");
-
+    this.render = this.sandbox.stub(RGB.prototype, "@@render");
+    const rgbs = new RGB.Collection([ this.a, this.b ]);
     rgbs[Animation.render]([
       { red: 0xff, green: 0x00, blue: 0x00 },
       { red: 0x00, green: 0xff, blue: 0x00 },
     ]);
 
-    test.equal(this.color.callCount, 2);
+    test.equal(this.render.callCount, 2);
+    test.deepEqual(this.render.firstCall.args[0], [ { red: 255, green: 0, blue: 0 } ]);
+    test.deepEqual(this.render.secondCall.args[0], [ { red: 0, green: 255, blue: 0 } ]);
     test.done();
   },
 };
-

--- a/test/rgb.js
+++ b/test/rgb.js
@@ -13,6 +13,8 @@ const rgbProtoProperties = [{
 }, {
   name: "blink"
 }, {
+  name: "pulse"
+}, {
   name: "stop"
 }];
 
@@ -44,7 +46,7 @@ exports["RGB"] = {
     });
 
     this.write = this.sandbox.spy(this.rgb, "write");
-
+    this.enqueue = this.sandbox.stub(Animation.prototype, "enqueue");
     done();
   },
 
@@ -469,6 +471,72 @@ exports["RGB"] = {
     test.done();
   },
 
+  pulse(test) {
+    test.expect(1);
+    this.rgb.color("#0000ff");
+    this.rgb.pulse();
+    test.equal(this.enqueue.callCount, 1);
+    test.done();
+  },
+  
+  pulseDuration(test) {
+    test.expect(2);
+
+    this.rgb.pulse(1010);
+
+    test.equal(this.enqueue.callCount, 1);
+
+    const duration = this.enqueue.lastCall.args[0].duration;
+
+    test.equal(duration, 1010);
+    test.done();
+  },
+
+  pulseCallback(test) {
+    test.expect(2);
+
+    const spy = this.sandbox.spy();
+
+    this.rgb.pulse(spy);
+
+    test.equal(this.enqueue.callCount, 1);
+
+    const onloop = this.enqueue.lastCall.args[0].onloop;
+
+    onloop();
+
+    test.equal(spy.callCount, 1);
+    test.done();
+  },
+
+  pulseDurationCallback(test) {
+    test.expect(3);
+
+    const spy = this.sandbox.spy();
+
+    this.rgb.pulse(1010, spy);
+
+    test.equal(this.enqueue.callCount, 1);
+
+    const duration = this.enqueue.lastCall.args[0].duration;
+    const onloop = this.enqueue.lastCall.args[0].onloop;
+
+    onloop();
+
+    test.equal(duration, 1010);
+    test.equal(spy.callCount, 1);
+    test.done();
+  },
+
+    pulseObject(test) {
+    test.expect(1);
+
+    this.rgb.color("#0000ff");
+    this.rgb.pulse({});
+    test.equal(this.enqueue.callCount, 1);
+    test.done();
+  },
+
   toggle(test) {
     test.expect(7);
 
@@ -749,9 +817,9 @@ exports["RGB"] = {
 
   "Animation.render"(test) {
     test.expect(1);
-    this.color = this.sandbox.stub(this.rgb, "color");
+    this.update = this.sandbox.stub(this.rgb, "update");
     this.rgb[Animation.render]([0]);
-    test.equal(this.color.callCount, 1);
+    test.equal(this.update.callCount, 1);
     test.done();
   },
 
@@ -876,11 +944,14 @@ exports["RGB - Cycling Operations"] = {
   },
 
   rgbCallsStopBeforeNextCyclingOperation(test) {
-    test.expect(1);
+    test.expect(2);
 
     this.rgb.blink();
+    this.rgb.pulse();
 
-    test.equal(this.stop.callCount, 1);
+    test.equal(this.stop.callCount, 2);
+    // pulse is an animation
+    test.equal(this.enqueue.callCount, 1);
 
     // Ensure that the interval is cleared.
     this.rgb.stop();


### PR DESCRIPTION
This PR does the following:
- adds one more revision to the `Rgb` class `pulse` method
- fixes unit tests in `test/rgb.collection.js` and `test/rgb.js` files
- adds new unit tests fro `Rgb` class `pulse` method
- updates the version of this package from 2.1.0-cdo.1 to 2.1.0-cdo.2

The update to `pulse` method address the situation when `on()` is called while the `Rgb` is pulsing. Beforehand, the `Rgb` would emit RGB values in the `tween` state of the `pulse` animation. Now the `Rgb` will emit the RGB values stored by  `prev`.

Screencast video before update:


https://user-images.githubusercontent.com/107423305/206532983-e3859f4c-c093-4559-affe-e6e1d5a2894e.mp4



Screencast video after update:


https://user-images.githubusercontent.com/107423305/206533045-169df5e1-200c-4f00-b584-1993da4e7f3c.mp4



## Testing

The unit tests that tested `Animation.render` in `test/rgb.collection.js` were revised since `Animation.render` was updated by [this PR](https://github.com/code-dot-org/johnny-five/pull/24). Instead of `color()`, the `update` method is called.  
Three tests broke when `grunt` was run.

<img width="735" alt="Screen Shot 2022-12-08 at 11 48 24 AM" src="https://user-images.githubusercontent.com/107423305/206527664-72c36f39-76f2-4659-a6b6-37156d4867c5.png">

These tests are now fixed and handful of new tests were added in `test/rgb.js` for the `pulse` method in the `Rgb` class. 

<img width="739" alt="Screen Shot 2022-12-08 at 11 49 47 AM" src="https://user-images.githubusercontent.com/107423305/206527813-7406300f-181a-42fb-a1a8-8a7015981ed2.png">

## Follow-up
I posted 3 PRs to mainline johnny-five so that we can hopefully move to using mainline johnny-five in the future.
Add option to round scaled sensor values - [PR](https://github.com/rwaldron/johnny-five/pull/1804)
Modify Animation temporalTTL so that it is configurable - [PR](https://github.com/rwaldron/johnny-five/pull/1805)
Adding a pulse method to the RGB class - [PR](https://github.com/rwaldron/johnny-five/pull/1803)

For the first 2 PRs, the implementations were a bit different from those for the forked code-dot-org/johnny-five in that the customizations were made to be configurable.

In the case that not all Code.org customizations are approved, we could plan to create a johnny-five wrapper so that we can still use mainline johnny-five and not have to maintain a forked project.

[Here](https://docs.google.com/document/d/1K4pTIEvBvdG537hD8rtUrxYoSpmUetdF8MfEYk6ZxIg/edit?usp=sharing) is a write-up of the costs/benefits of using mainline vs maintaining forked project.
[This](https://codedotorg.atlassian.net/browse/SL-14) is the original investigation in moving off the johnny-five fork.