### PR TITLE
Update version to 2.1.0-cdo.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "johnny-five",
-  "version": "2.1.0",
+  "version": "2.1.0-cdo.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@code-dot-org/johnny-five",
   "description": "Code.org fork of rwaldron/johnny-five: The JavaScript Robotics and Hardware Programming Framework. Use with: Arduino (all models), Electric Imp, Beagle Bone, Intel Galileo & Edison, Linino One, Pinoccio, pcDuino3, Raspberry Pi, Particle/Spark Core & Photon, Tessel 2, TI Launchpad and more!",
-  "version": "2.1.0-cdo.2",
+  "version": "2.1.0-cdo.3",
   "homepage": "https://johnny-five.io",
   "author": "Rick Waldron <waldron.rick@gmail.com>",
   "keywords": [


### PR DESCRIPTION
This PR updates the version of `@code-dot-org/johnny-five` to 2.1.0-cdo.3.
I attempted to publish version 2.1.0-cdo.2 to the NPM registry after merging [this PR](https://github.com/code-dot-org/johnny-five/pull/26) which included an update to the Rgb class method `pulse` and additional unit tests.
However, I received the following error when I ran `npm version 2.1.0-cdo.2`:

<img width="902" alt="Screen Shot 2022-12-12 at 10 22 53 AM" src="https://user-images.githubusercontent.com/107423305/207106103-f62cc294-0213-4000-af05-9ad15ad11e41.png">

This was puzzling since the last version published was 2.1.0-cdo.1 shown when I ran `npm view @code-dot-org/johnny-five versions`. (Ignore the 2.1.0-cdo.3 since published!):

<img width="746" alt="Screen Shot 2022-12-12 at 11 43 57 AM" src="https://user-images.githubusercontent.com/107423305/207116263-975cb894-21ef-42dd-8f8f-f332442619c5.png">

But @bencodeorg pointed me to [this post](https://github.com/npm/cli/issues/5058). After running `npm view @code-dot-org/johnny-five time`, I remembered that I published by mistake, then unpublished version 2.1.0-cdo.2 a couple months ago:

<img width="724" alt="Screen Shot 2022-12-12 at 10 35 00 AM" src="https://user-images.githubusercontent.com/107423305/207116738-dc3845ce-30ae-400e-bd16-db6bb7461617.png">

Once you publish/unpublish a version, it is unique and cannot be reused. See [https://docs.npmjs.com/unpublishing-packages-from-the-registry](https://docs.npmjs.com/unpublishing-packages-from-the-registr).

Thus, the newest version of `@code-dot-org/johnny-five` is now at 2.1.0-cdo.3.


